### PR TITLE
Reflect that time is required for data in the factory

### DIFF
--- a/events/src/main/java/org/opentest4j/reporting/events/core/CoreFactory.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/CoreFactory.java
@@ -21,6 +21,7 @@ import org.opentest4j.reporting.events.api.Factory;
 
 import java.io.File;
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -131,8 +132,8 @@ public class CoreFactory {
 	 *
 	 * @return Data factory
 	 */
-	public static Factory<Data> data() {
-		return Data::new;
+	public static Factory<Data> data(LocalDateTime timestamp) {
+		return context -> new Data(context).withTime(timestamp);
 	}
 
 	/**

--- a/tooling/src/test/java/org/opentest4j/reporting/tooling/converter/DefaultConverterTests.java
+++ b/tooling/src/test/java/org/opentest4j/reporting/tooling/converter/DefaultConverterTests.java
@@ -31,6 +31,7 @@ import org.xmlunit.util.Convert;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -112,13 +113,13 @@ class DefaultConverterTests {
 	void mergesReportEntries() throws Exception {
 		writeXml(sourceFile, writer -> writer.append(started("1", Instant.now(), "test"), started -> started //
 				.append(attachments(), attachments -> attachments //
-						.append(data(), data -> data.addEntry("started", "1")))) //
+						.append(data(LocalDateTime.now()), data -> data.addEntry("started", "1")))) //
 				.append(reported("1", Instant.now()), reported -> reported //
 						.append(attachments(), attachments -> attachments //
-								.append(data(), data -> data.addEntry("reported", "2")))) //
+								.append(data(LocalDateTime.now()), data -> data.addEntry("reported", "2")))) //
 				.append(finished("1", Instant.now()), finished -> finished //
 						.append(attachments(), attachments -> attachments //
-								.append(data(), data -> data.addEntry("finished", "3")))));
+								.append(data(LocalDateTime.now()), data -> data.addEntry("finished", "3")))));
 
 		new DefaultConverter().convert(sourceFile, targetFile);
 


### PR DESCRIPTION
The `time` attribute on `entry` is required.
Enforce it in the factory method?