### PR TITLE
Use GSON instead of Jackson to avoid affecting downstream projects

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,15 @@
 [versions]
 eclipse = "4.32.0"
 immutables = "2.10.1"
-jackson = "2.18.0"
 
 [libraries]
 archunit = { module = "com.tngtech.archunit:archunit-junit5", version = "1.3.0" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.26.3" }
+gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
 immutables-valueAnnotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
 joox = { module = "org.jooq:joox", version = "2.0.1" }
-jsonSanitizer = { module = "com.mikesamuel:json-sanitizer", version = "1.2.3" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.11.3" }
 junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting", version = "1.11.3" }
 log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version = "2.24.1" }

--- a/tooling-core/build.gradle.kts
+++ b/tooling-core/build.gradle.kts
@@ -9,8 +9,7 @@ dependencies {
     api(projects.schema)
     implementation(projects.events)
     implementation(projects.toolingSpi)
-    implementation(libs.jackson.dataformat.xml)
-    implementation(libs.jsonSanitizer)
+    implementation(libs.gson)
     implementation(libs.joox)
 
     testImplementation(libs.assertj.core)

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -97,8 +97,12 @@ public class CoreContributor implements Contributor {
 				type = child.getLocalName().substring(0, child.getLocalName().length() - "Source".length());
 			}
 			var subsection = Section.builder().title(capitalize(type));
+
 			var attributes = KeyValuePairs.builder();
-			stream(child.getAttributes()).forEach(it -> attributes.putContent(it.getNodeName(), it.getNodeValue()));
+			stream(child.getAttributes()) //
+					.filter(it -> it.getNodeValue() != null && !it.getNodeValue().isEmpty()) //
+					.forEach(it -> attributes.putContent(it.getNodeName(), it.getNodeValue()));
+
 			var filePosition = $(child).child("filePosition").first();
 			if (filePosition.isNotEmpty()) {
 				attributes.putContent("line", filePosition.attr("line"));
@@ -107,6 +111,7 @@ public class CoreContributor implements Contributor {
 					attributes.putContent("column", column);
 				}
 			}
+
 			subsection.addBlock(attributes.build());
 			return subsection.build();
 		}).forEach(subsections::addContent);

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriter.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriter.java
@@ -16,16 +16,21 @@
 
 package org.opentest4j.reporting.tooling.core.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.json.JsonSanitizer;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializer;
 import org.opentest4j.reporting.events.core.Result;
 import org.opentest4j.reporting.events.root.Events;
 import org.opentest4j.reporting.schema.Namespace;
 import org.opentest4j.reporting.tooling.core.converter.DefaultConverter;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Block;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
+import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Labels;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Paragraph;
+import org.opentest4j.reporting.tooling.spi.htmlreport.PreFormattedOutput;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Section;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Subsections;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -76,12 +81,33 @@ public class DefaultHtmlReportWriter implements HtmlReportWriter {
 		Files.writeString(htmlFile, content);
 	}
 
-	private static String toJavascript(ArrayList<Execution> executions) throws JsonProcessingException {
-		var jsonMapper = new ObjectMapper();
-		jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+	private static String toJavascript(List<Execution> executions) {
+		var gson = new GsonBuilder() //
+				.registerTypeHierarchyAdapter(Section.class,
+					(JsonSerializer<Section>) (section, typeOfSrc, context) -> {
+						var jsonObject = new JsonObject();
+						jsonObject.addProperty("title", section.getTitle());
+						jsonObject.add("blocks", context.serialize(section.getBlocks()));
+						return jsonObject;
+					}) //
+				.registerTypeHierarchyAdapter(KeyValuePairs.class, blockSerializer("kvp")) //
+				.registerTypeHierarchyAdapter(Labels.class, blockSerializer("labels")) //
+				.registerTypeHierarchyAdapter(Paragraph.class, blockSerializer("p")) //
+				.registerTypeHierarchyAdapter(PreFormattedOutput.class, blockSerializer("pre")) //
+				.registerTypeHierarchyAdapter(Subsections.class, blockSerializer("sub")) //
+				.disableJdkUnsafe() //
+				.create();
 
-		var json = JsonSanitizer.sanitize(jsonMapper.writeValueAsString(executions));
-		return "globalThis.testExecutions = " + json + ";";
+		return "globalThis.testExecutions = " + gson.toJson(executions) + ";";
+	}
+
+	private static JsonSerializer<Block<?>> blockSerializer(String type) {
+		return (block, typeOfSrc, context) -> {
+			var jsonObject = new JsonObject();
+			jsonObject.addProperty("type", type);
+			jsonObject.add("content", context.serialize(block.getContent()));
+			return jsonObject;
+		};
 	}
 
 	private Execution extractData(IdGenerator idGenerator, Element rootElement, String name) {
@@ -99,7 +125,7 @@ public class DefaultHtmlReportWriter implements HtmlReportWriter {
 		return execution;
 	}
 
-	static class Execution {
+	private static class Execution {
 
 		public final String id;
 		public final String name;
@@ -117,7 +143,7 @@ public class DefaultHtmlReportWriter implements HtmlReportWriter {
 		}
 	}
 
-	static class TestNode {
+	private static class TestNode {
 
 		public final String id;
 		public final String name;

--- a/tooling-spi/build.gradle.kts
+++ b/tooling-spi/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     annotationProcessor(libs.immutables.value)
     compileOnly(libs.immutables.valueAnnotations)
-    compileOnlyApi(libs.jackson.annotations)
 }
 
 tasks {

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Block.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Block.java
@@ -16,16 +16,11 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.SIMPLE_NAME;
-
 /**
  * A block to be rendered in the HTML report.
  *
  * @param <T> the type of content
  */
-@JsonTypeInfo(use = SIMPLE_NAME, property = "type")
 public interface Block<T> {
 
 	/**

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/KeyValuePairs.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/KeyValuePairs.java
@@ -16,7 +16,6 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value.Immutable;
 
 import java.util.Map;
@@ -25,7 +24,6 @@ import java.util.Map;
  * A block of key-value pairs to be rendered in the HTML report.
  */
 @Immutable
-@JsonTypeName("kvp")
 public interface KeyValuePairs extends Block<Map<String, String>> {
 
 	/**

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Labels.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Labels.java
@@ -16,7 +16,6 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value.Immutable;
 
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.List;
  * A block of labels to be rendered in the HTML report.
  */
 @Immutable
-@JsonTypeName("labels")
 public interface Labels extends Block<List<String>> {
 
 	/**

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Paragraph.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Paragraph.java
@@ -16,14 +16,12 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value.Immutable;
 
 /**
  * A block of text to be rendered in the HTML report.
  */
 @Immutable
-@JsonTypeName("p")
 public interface Paragraph extends Block<String> {
 
 	/**

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/PreFormattedOutput.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/PreFormattedOutput.java
@@ -16,14 +16,12 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value.Immutable;
 
 /**
  * A block of pre-formatted text to be rendered in the HTML report.
  */
 @Immutable
-@JsonTypeName("pre")
 public interface PreFormattedOutput extends Block<String> {
 
 	/**

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Section.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Section.java
@@ -16,7 +16,6 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
@@ -57,7 +56,6 @@ public interface Section {
 	 * <p>This is used to sort the all {@linkplain Contributor contributed}
 	 * sections in the HTML report.
 	 */
-	@JsonIgnore
 	@Default
 	default int getOrder() {
 		return 0;

--- a/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Subsections.java
+++ b/tooling-spi/src/main/java/org/opentest4j/reporting/tooling/spi/htmlreport/Subsections.java
@@ -16,7 +16,6 @@
 
 package org.opentest4j.reporting.tooling.spi.htmlreport;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value.Immutable;
 
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.List;
  * A block of subsections to be rendered in the HTML report.
  */
 @Immutable
-@JsonTypeName("sub")
 public interface Subsections extends Block<List<Section>> {
 
 	/**


### PR DESCRIPTION
Having Jackson annotations on the types in the tooling-spi project
caused downstream projects implementing the SPI to have a couple of
Jackson JARs and their dependencies on the classpath, including a
different XML API implementation. Switching to GSON avoids that and also
lets us get rid of the extra dependency on json-sanitizer in
tooling-core because GSON already escapes problematic HTML characters.
