### PR TITLE
Use BND to include OSGi metadata in JAR manifests

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,7 @@ repositories {
 }
 
 dependencies {
+    implementation(libs.plugins.bnd.markerCoordinates)
     implementation(libs.plugins.spotless.markerCoordinates)
 }
 

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -3,6 +3,7 @@ import java.nio.file.Files
 
 plugins {
     `java-library`
+    id("biz.aQute.bnd.builder")
     id("com.diffplug.spotless")
     id("publishing-conventions")
 }
@@ -57,7 +58,16 @@ tasks {
     }
     jar {
         manifest {
-            attributes("Automatic-Module-Name" to "org.opentest4j.reporting.${project.name.replace('-', '.')}")
+            val moduleName = "org.opentest4j.reporting.${project.name.replace('-', '.')}"
+            attributes(
+                "Automatic-Module-Name" to moduleName,
+                "Bundle-Name" to project.name,
+                "Bundle-Description" to project.name,
+                "Bundle-DocURL" to "https://github.com/ota4j-team/open-test-reporting",
+                "Bundle-Vendor" to "opentest4j.org",
+                "-exportcontents" to "org.opentest4j.reporting.*",
+                "Bundle-SymbolicName" to moduleName,
+            )
         }
     }
     javadoc {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ eclipse-platform = { module = "org.eclipse.platform:org.eclipse.platform", versi
 junit = ["junit-jupiter", "junit-platform-reporting"]
 
 [plugins]
+bnd = { id = "biz.aQute.bnd.builder", version = "7.0.0" }
 node = { id = "com.github.node-gradle.node", version = "7.1.0" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.0.BETA4" }


### PR DESCRIPTION
This allows downstream projects such as JUnit to find matching bundles
based on their exported packages etc.
