### PR TITLE
Introduce Git namespace extensions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,10 +95,17 @@ The following example shows the result of converting the above event-based repor
 <3> child node of "test" with timestamp, duration, and result status
 
 [#xml-extensions]
-=== Java extensions
+=== Schema extensions
 
 All schema definitions mentioned so far are language-agnostic.
+
+==== Java
+
 In order to report Java-specific attributes, e.g. the class or method name of a test, an extension schema is defined in link:schema/src/main/resources/org/opentest4j/reporting/schema/java.xsd[java.xsd].
+
+==== Git
+
+In order to include Git-specific metadata, e.g. the commit hash or branch name, an extension schema is defined in link:schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd[git.xsd].
 
 [TIP]
 ====

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -132,8 +132,11 @@ tasks {
         }
 
         doFirst {
-            // Delete existing event-based report files
-            eventXmlFiles.files.forEach {
+            files(reports.junitXml.outputLocation.get().asFileTree.matching {
+                include("junit-platform-events-*.xml")
+                include("junit-platform-events-*.html")
+                include("hierarchy.xml")
+            }).files.forEach {
                 Files.delete(it.toPath())
             }
         }

--- a/events/src/main/java/org/opentest4j/reporting/events/core/CpuCores.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/CpuCores.java
@@ -26,7 +26,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class CpuCores extends ChildElement<Infrastructure, CpuCores> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "cpuCores");
+	/**
+	 * Qualified name of the {@code cpuCores} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "cpuCores");
 
 	CpuCores(Context context, int value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/core/HostName.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/HostName.java
@@ -26,7 +26,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class HostName extends ChildElement<Infrastructure, HostName> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "hostName");
+	/**
+	 * Qualified name of the {@code hostName} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "hostName");
 
 	HostName(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/core/OperatingSystem.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/OperatingSystem.java
@@ -26,7 +26,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class OperatingSystem extends ChildElement<Infrastructure, OperatingSystem> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "operatingSystem");
+	/**
+	 * Qualified name of the {@code operatingSystem} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "operatingSystem");
 
 	OperatingSystem(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/core/UserName.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/UserName.java
@@ -26,7 +26,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class UserName extends ChildElement<Infrastructure, UserName> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "userName");
+	/**
+	 * Qualified name of the {@code userName} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "userName");
 
 	UserName(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Branch.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Branch.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.git;
+
+import org.opentest4j.reporting.events.api.ChildElement;
+import org.opentest4j.reporting.events.api.Context;
+import org.opentest4j.reporting.events.core.Infrastructure;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+
+/**
+ * The {code branch} element of the Git namespace.
+ */
+public class Branch extends ChildElement<Infrastructure, Branch> {
+
+	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "branch");
+
+	Branch(Context context, String value) {
+		super(context, ELEMENT);
+		withContent(value);
+	}
+}

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Branch.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Branch.java
@@ -27,7 +27,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class Branch extends ChildElement<Infrastructure, Branch> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "branch");
+	/**
+	 * Qualified name of the {@code branch} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "branch");
 
 	Branch(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.git;
+
+import org.opentest4j.reporting.events.api.ChildElement;
+import org.opentest4j.reporting.events.api.Context;
+import org.opentest4j.reporting.events.core.Infrastructure;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+
+/**
+ * The {@code commit} element of the Git namespace.
+ */
+public class Commit extends ChildElement<Infrastructure, Commit> {
+
+	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "commit");
+	private static final QualifiedName ABBREVIATED_HASH = QualifiedName.of(Namespace.REPORTING_GIT, "abbreviatedHash");
+
+	Commit(Context context, String hash) {
+		super(context, ELEMENT);
+		withContent(hash);
+	}
+
+	/**
+	 * Set the {@code abbreviatedHash} attribute of this element.
+	 *
+	 * @param abbreviatedHash the abbreviated commit hash
+	 * @return this element
+	 */
+	public Commit withAbbreviatedHash(String abbreviatedHash) {
+		withAttribute(ABBREVIATED_HASH, abbreviatedHash);
+		return this;
+	}
+}

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
@@ -28,21 +28,9 @@ import org.opentest4j.reporting.schema.QualifiedName;
 public class Commit extends ChildElement<Infrastructure, Commit> {
 
 	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "commit");
-	private static final QualifiedName ABBREVIATED_HASH = QualifiedName.of(Namespace.REPORTING_GIT, "abbreviatedHash");
 
 	Commit(Context context, String hash) {
 		super(context, ELEMENT);
 		withContent(hash);
-	}
-
-	/**
-	 * Set the {@code abbreviatedHash} attribute of this element.
-	 *
-	 * @param abbreviatedHash the abbreviated commit hash
-	 * @return this element
-	 */
-	public Commit withAbbreviatedHash(String abbreviatedHash) {
-		withAttribute(ABBREVIATED_HASH, abbreviatedHash);
-		return this;
 	}
 }

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
@@ -27,7 +27,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class Commit extends ChildElement<Infrastructure, Commit> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "commit");
+	/**
+	 * Qualified name of the {@code commit} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "commit");
 
 	Commit(Context context, String hash) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/git/GitFactory.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/GitFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.git;
+
+import org.opentest4j.reporting.events.api.Factory;
+
+/**
+ * Factory for elements of the Git namespace.
+ */
+public class GitFactory {
+
+	private GitFactory() {
+	}
+
+	/**
+	 * Create a factory for {@link Repository} elements.
+	 *
+	 * @return Repository factory
+	 */
+	public static Factory<Repository> repository() {
+		return Repository::new;
+	}
+
+	/**
+	 * Create a factory for {@link Branch} elements.
+	 *
+	 * @param name the branch name
+	 * @return Branch factory
+	 */
+	public static Factory<Branch> branch(String name) {
+		return context -> new Branch(context, name);
+	}
+
+	/**
+	 * Create a factory for {@link Commit} elements.
+	 *
+	 * @param hash the commit hash
+	 * @return Commit factory
+	 */
+	public static Factory<Commit> commit(String hash) {
+		return context -> new Commit(context, hash);
+	}
+
+	/**
+	 * Create a factory for {@link Status} elements.
+	 *
+	 * @param output the status output of Git
+	 * @return Status factory
+	 */
+	public static Factory<Status> status(String output) {
+		return context -> new Status(context, output);
+	}
+
+}

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Repository.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Repository.java
@@ -27,7 +27,11 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class Repository extends ChildElement<Infrastructure, Repository> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "repository");
+	/**
+	 * Qualified name of the {@code repository} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "repository");
+
 	private static final QualifiedName ORIGIN_URL = QualifiedName.of(Namespace.REPORTING_GIT, "originUrl");
 
 	Repository(Context context) {

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Repository.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Repository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.git;
+
+import org.opentest4j.reporting.events.api.ChildElement;
+import org.opentest4j.reporting.events.api.Context;
+import org.opentest4j.reporting.events.core.Infrastructure;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+
+/**
+ * The {@code repository} element of the Git namespace.
+ */
+public class Repository extends ChildElement<Infrastructure, Repository> {
+
+	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "repository");
+	private static final QualifiedName ORIGIN_URL = QualifiedName.of(Namespace.REPORTING_GIT, "originUrl");
+
+	Repository(Context context) {
+		super(context, ELEMENT);
+	}
+
+	/**
+	 * Set the {@code originUrl} attribute of this element.
+	 *
+	 * @param originUrl the URL of the 'origin' remote
+	 * @return this element
+	 */
+	public Repository withOriginUrl(String originUrl) {
+		withAttribute(ORIGIN_URL, originUrl);
+		return this;
+	}
+}

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Status.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Status.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.git;
+
+import org.opentest4j.reporting.events.api.ChildElement;
+import org.opentest4j.reporting.events.api.Context;
+import org.opentest4j.reporting.events.core.Infrastructure;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+
+/**
+ * The {@code status} element of the Git namespace.
+ */
+public class Status extends ChildElement<Infrastructure, Status> {
+
+	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "status");
+
+	Status(Context context, String output) {
+		super(context, ELEMENT);
+		withCDataSection(output);
+	}
+
+	/**
+	 * Set the {@code clean} attribute of this element.
+	 *
+	 * @param clean whether the working directory clean contains no changes or untracked files
+	 * @return this element
+	 */
+	public Status withClean(boolean clean) {
+		withAttribute(QualifiedName.of(Namespace.REPORTING_GIT, "clean"), String.valueOf(clean));
+		return this;
+	}
+}

--- a/events/src/main/java/org/opentest4j/reporting/events/git/Status.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/git/Status.java
@@ -27,7 +27,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class Status extends ChildElement<Infrastructure, Status> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "status");
+	/**
+	 * Qualified name of the {@code status} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_GIT, "status");
 
 	Status(Context context, String output) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/java/FileEncoding.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/java/FileEncoding.java
@@ -27,7 +27,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class FileEncoding extends ChildElement<Infrastructure, FileEncoding> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_JAVA, "fileEncoding");
+	/**
+	 * Qualified name of the {@code fileEncoding} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_JAVA, "fileEncoding");
 
 	FileEncoding(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/main/java/org/opentest4j/reporting/events/java/JavaVersion.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/java/JavaVersion.java
@@ -27,7 +27,10 @@ import org.opentest4j.reporting.schema.QualifiedName;
  */
 public class JavaVersion extends ChildElement<Infrastructure, JavaVersion> {
 
-	private static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_JAVA, "javaVersion");
+	/**
+	 * Qualified name of the {@code javaVersion} element.
+	 */
+	public static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_JAVA, "javaVersion");
 
 	JavaVersion(Context context, String value) {
 		super(context, ELEMENT);

--- a/events/src/test/java/DocumentWriterSample.java
+++ b/events/src/test/java/DocumentWriterSample.java
@@ -34,6 +34,7 @@ public class DocumentWriterSample {
 
 		NamespaceRegistry namespaceRegistry = NamespaceRegistry.builder(Namespace.REPORTING_CORE) // <1>
 				.add("e", Namespace.REPORTING_EVENTS) //
+				.add("git", Namespace.REPORTING_GIT) //
 				.add("java", Namespace.REPORTING_JAVA) //
 				.build();
 

--- a/schema/src/main/java/org/opentest4j/reporting/schema/Namespace.java
+++ b/schema/src/main/java/org/opentest4j/reporting/schema/Namespace.java
@@ -47,6 +47,11 @@ public class Namespace {
 	public static final Namespace REPORTING_JAVA = Namespace.of("https://schemas.opentest4j.org/reporting/java/0.1.0");
 
 	/**
+	 * Open Test Reporting Git namespace
+	 */
+	public static final Namespace REPORTING_GIT = Namespace.of("https://schemas.opentest4j.org/reporting/git/0.1.0");
+
+	/**
 	 * Open Test Reporting hierarchical namespace
 	 */
 	public static final Namespace REPORTING_HIERARCHY = Namespace.of(

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
@@ -31,13 +31,8 @@
       <xs:simpleContent>
         <xs:extension base="xs:string">
           <xs:annotation>
-            <xs:documentation>the full commit hash</xs:documentation>
+            <xs:documentation>the commit hash</xs:documentation>
           </xs:annotation>
-          <xs:attribute name="abbreviatedHash" type="xs:string" use="required">
-            <xs:annotation>
-              <xs:documentation>the abbreviated commit hash</xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
@@ -1,0 +1,65 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="https://schemas.opentest4j.org/reporting/git/0.1.0"
+           elementFormDefault="qualified">
+
+  <!-- infrastructure -->
+
+  <xs:element name="repository">
+    <xs:complexType>
+      <xs:attribute name="originUrl" type="xs:anyURI" use="required">
+        <xs:annotation>
+          <xs:documentation>the URL of the 'origin' remote of the Git repository</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="branch">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation>the branch the HEAD commit is pointing to, if any</xs:documentation>
+          </xs:annotation>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="commit">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation>the full commit hash</xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="abbreviatedHash" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>the abbreviated commit hash</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="status">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation>the output of `git status --porcelain`, potentially empty</xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="clean" type="xs:boolean" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                whether the working directory clean contains no changes or untracked files
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -17,6 +17,11 @@
 package org.opentest4j.reporting.tooling.core.htmlreport;
 
 import org.joox.Match;
+import org.opentest4j.reporting.events.core.CpuCores;
+import org.opentest4j.reporting.events.core.HostName;
+import org.opentest4j.reporting.events.core.OperatingSystem;
+import org.opentest4j.reporting.events.core.UserName;
+import org.opentest4j.reporting.schema.QualifiedName;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
 import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Labels;
@@ -29,11 +34,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import static java.util.stream.Collectors.toList;
 import static org.joox.JOOX.$;
+import static org.joox.JOOX.and;
+import static org.joox.JOOX.namespaceURI;
+import static org.joox.JOOX.selector;
 import static org.opentest4j.reporting.tooling.core.util.DomUtils.stream;
 
 /**
@@ -62,10 +70,10 @@ public class CoreContributor implements Contributor {
 		var infrastructure = $(element).child("infrastructure");
 
 		var table = new LinkedHashMap<String, String>();
-		addToTable(infrastructure, "hostName", "Hostname", table);
-		addToTable(infrastructure, "userName", "Username", table);
-		addToTable(infrastructure, "operatingSystem", "Operating system", table);
-		addToTable(infrastructure, "cpuCores", "CPU cores", table);
+		addToTable(infrastructure, HostName.ELEMENT, "Hostname", table::put);
+		addToTable(infrastructure, UserName.ELEMENT, "Username", table::put);
+		addToTable(infrastructure, OperatingSystem.ELEMENT, "Operating system", table::put);
+		addToTable(infrastructure, CpuCores.ELEMENT, "CPU cores", table::put);
 
 		if (table.isEmpty()) {
 			return Optional.empty();
@@ -152,11 +160,16 @@ public class CoreContributor implements Contributor {
 		return Optional.of(Section.builder().title("Attachments").order(30).addBlock(subsections.build()).build());
 	}
 
-	static void addToTable(Match march, String elementName, String label, Map<String, String> table) {
-		var value = march.child(elementName).text();
+	static void addToTable(Match march, QualifiedName elementName, String label, BiConsumer<String, String> table) {
+		var value = findChild(march, elementName).text();
 		if (value != null) {
-			table.put(label, value);
+			table.accept(label, value);
 		}
+	}
+
+	static Match findChild(Match march, QualifiedName elementName) {
+		return march.child(
+			and(namespaceURI(elementName.getNamespace().getUri()), selector(elementName.getSimpleName())));
 	}
 
 	private static String capitalize(String value) {

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/GitContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/GitContributor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.tooling.core.htmlreport;
+
+import org.joox.Match;
+import org.opentest4j.reporting.events.git.Branch;
+import org.opentest4j.reporting.events.git.Commit;
+import org.opentest4j.reporting.events.git.Repository;
+import org.opentest4j.reporting.events.git.Status;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Block;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
+import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
+import org.opentest4j.reporting.tooling.spi.htmlreport.PreFormattedOutput;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Section;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Subsections;
+import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.joox.JOOX.$;
+import static org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.addToTable;
+import static org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.findChild;
+
+/**
+ * Contributes sections to the HTML report elements in the git schema.
+ */
+public class GitContributor implements Contributor {
+
+	@Override
+	public List<Section> contributeSectionsForExecution(Element executionElement) {
+		var sections = new ArrayList<Section>();
+		var infrastructure = $(executionElement).child("infrastructure");
+		createGitSection(infrastructure).ifPresent(sections::add);
+		return sections;
+
+	}
+
+	private static Optional<Section> createGitSection(Match infrastructure) {
+
+		var table = KeyValuePairs.builder();
+		Block<?> statusBlock = null;
+
+		var originUrl = findChild(infrastructure, Repository.ELEMENT).attr("originUrl");
+		if (originUrl != null) {
+			table.putContent("Origin", originUrl);
+		}
+
+		addToTable(infrastructure, Branch.ELEMENT, "Branch", table::putContent);
+		addToTable(infrastructure, Commit.ELEMENT, "Commit hash", table::putContent);
+
+		var status = findChild(infrastructure, Status.ELEMENT);
+		if (status.isNotEmpty()) {
+			table.putContent("Clean", status.attr("clean"));
+			if (!status.text().isBlank()) {
+				var codeBlock = PreFormattedOutput.builder().content(status.text()).build();
+				var subsection = Section.builder().title("Status of working tree").addBlock(codeBlock).build();
+				statusBlock = Subsections.builder().addContent(subsection).build();
+			}
+		}
+
+		var sectionBuilder = Section.builder().title("Git").order(15);
+
+		var keyValuePairs = table.build();
+		if (!keyValuePairs.getContent().isEmpty()) {
+			sectionBuilder.addBlock(keyValuePairs);
+		}
+
+		if (statusBlock != null) {
+			sectionBuilder.addBlock(statusBlock);
+		}
+
+		var section = sectionBuilder.build();
+
+		return section.getBlocks().isEmpty() ? Optional.empty() : Optional.of(section);
+	}
+}

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/JavaContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/JavaContributor.java
@@ -17,6 +17,8 @@
 package org.opentest4j.reporting.tooling.core.htmlreport;
 
 import org.joox.Match;
+import org.opentest4j.reporting.events.java.FileEncoding;
+import org.opentest4j.reporting.events.java.JavaVersion;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
 import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
 import org.opentest4j.reporting.tooling.spi.htmlreport.PreFormattedOutput;
@@ -57,8 +59,8 @@ public class JavaContributor implements Contributor {
 
 	private static Optional<Section> createJvmSection(Match infrastructure) {
 		var table = new LinkedHashMap<String, String>();
-		addToTable(infrastructure, "javaVersion", "Java version", table);
-		addToTable(infrastructure, "fileEncoding", "File encoding", table);
+		addToTable(infrastructure, JavaVersion.ELEMENT, "Java version", table::put);
+		addToTable(infrastructure, FileEncoding.ELEMENT, "File encoding", table::put);
 		String maxHeapSize = infrastructure.child("heapSize").attr("max");
 		if (maxHeapSize != null) {
 			table.put("Max heap size",

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidator.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidator.java
@@ -55,6 +55,7 @@ public class DefaultValidator implements Validator {
 		Namespace.REPORTING_EVENTS, "/org/opentest4j/reporting/schema/events.xsd", //
 		Namespace.REPORTING_HIERARCHY, "/org/opentest4j/reporting/schema/hierarchy.xsd", //
 		Namespace.REPORTING_CORE, "/org/opentest4j/reporting/schema/core.xsd", //
+		Namespace.REPORTING_GIT, "/org/opentest4j/reporting/schema/git.xsd", //
 		Namespace.REPORTING_JAVA, "/org/opentest4j/reporting/schema/java.xsd");
 
 	private final SchemaFactory schemaFactory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);

--- a/tooling-core/src/main/resources/META-INF/services/org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
+++ b/tooling-core/src/main/resources/META-INF/services/org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
@@ -1,2 +1,3 @@
 org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor
+org.opentest4j.reporting.tooling.core.htmlreport.GitContributor
 org.opentest4j.reporting.tooling.core.htmlreport.JavaContributor


### PR DESCRIPTION
Resolves #28.

Corresponding change in JUnit:

- https://github.com/junit-team/junit5/pull/4126

## Output

### Dirty working tree

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<h:execution xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0" xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:git="https://schemas.opentest4j.org/reporting/git/0.1.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0" xmlns:junit="https://schemas.junit.org/open-test-reporting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
  <infrastructure>
    <hostName>coriol</hostName>
    <userName>marc</userName>
    <operatingSystem>Linux</operatingSystem>
    <cpuCores>16</cpuCores>
    <java:javaVersion>17.0.12</java:javaVersion>
    <java:fileEncoding>UTF-8</java:fileEncoding>
    <java:heapSize max="536870912"/>
    <git:repository originUrl="https://github.com/ota4j-team/open-test-reporting.git"/>
    <git:branch>marc/git-metadata</git:branch>
    <git:commit>2f8e75e027b13015f02919160b7c705e72ca2b1f</git:commit>
    <git:status clean="false"><![CDATA[ M buildSrc/src/main/kotlin/java-conventions.gradle.kts
 M events/src/main/java/org/opentest4j/reporting/events/core/CpuCores.java
 M events/src/main/java/org/opentest4j/reporting/events/core/HostName.java
 M events/src/main/java/org/opentest4j/reporting/events/core/OperatingSystem.java
 M events/src/main/java/org/opentest4j/reporting/events/core/UserName.java
 M events/src/main/java/org/opentest4j/reporting/events/git/Branch.java
 M events/src/main/java/org/opentest4j/reporting/events/git/Commit.java
 M events/src/main/java/org/opentest4j/reporting/events/git/Repository.java
 M events/src/main/java/org/opentest4j/reporting/events/git/Status.java
 M events/src/main/java/org/opentest4j/reporting/events/java/FileEncoding.java
 M events/src/main/java/org/opentest4j/reporting/events/java/JavaVersion.java
 M schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
 M settings.gradle.kts
 M tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
 M tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/JavaContributor.java
 M tooling-core/src/main/resources/META-INF/services/org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
?? tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/GitContributor.java]]></git:status>
  </infrastructure>
  <h:root duration="PT0.075506752S" name="JUnit Jupiter" start="2024-11-14T13:24:07.187594237Z">
	<!-- ... -->
  </h:root>
</h:execution>
```

![Screenshot 2024-11-14 at 14-25-59 Open Test Report](https://github.com/user-attachments/assets/0b3dce83-33c8-424f-adb5-4e2339214e8a)


### Clean working tree

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<h:execution xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0" xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:git="https://schemas.opentest4j.org/reporting/git/0.1.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0" xmlns:junit="https://schemas.junit.org/open-test-reporting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
  <infrastructure>
    <hostName>coriol</hostName>
    <userName>marc</userName>
    <operatingSystem>Linux</operatingSystem>
    <cpuCores>16</cpuCores>
    <java:javaVersion>17.0.12</java:javaVersion>
    <java:fileEncoding>UTF-8</java:fileEncoding>
    <java:heapSize max="536870912"/>
    <git:repository originUrl="https://github.com/ota4j-team/open-test-reporting.git"/>
    <git:branch>marc/git-metadata</git:branch>
    <git:commit>56b3830afdceed269251a095dee064094404eb06</git:commit>
    <git:status clean="true"/>
  </infrastructure>
  <h:root duration="PT0.07207132S" name="JUnit Jupiter" start="2024-11-14T13:44:51.443164385Z">
	<!-- ... -->
  </h:root>
</h:execution>

```

![image](https://github.com/user-attachments/assets/cbc53a37-3b09-427e-a7e6-bd1e5a2bb004)

