### PR TITLE
Add support for file attachments to XML schema

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Open Test Reporting
-:schemaVersion: 0.1.0
-:openTestReportingVersion: 0.1.0-M2
+:schemaVersion: 0.2.0
+:openTestReportingVersion: 0.2.0-SNAPSHOT
 
 <<xml-formats, XML>> and <<cli-html-report, HTML>> test reporting formats that are agnostic of testing framework and programming language.
 

--- a/events/src/main/java/org/opentest4j/reporting/events/core/CoreFactory.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/CoreFactory.java
@@ -19,7 +19,6 @@ package org.opentest4j.reporting.events.core;
 import org.opentest4j.reporting.events.api.Element;
 import org.opentest4j.reporting.events.api.Factory;
 
-import java.io.File;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -138,6 +137,16 @@ public class CoreFactory {
 	}
 
 	/**
+	 * Create a factory for {@link File} elements.
+	 *
+	 * @param timestamp the timestamp of creating the file
+	 * @return File factory
+	 */
+	public static Factory<File> file(LocalDateTime timestamp) {
+		return context -> new File(context).withTime(timestamp);
+	}
+
+	/**
 	 * Create a factory for {@link Result} elements.
 	 *
 	 * @param status the status of the result
@@ -163,7 +172,7 @@ public class CoreFactory {
 	 * @param file the source file
 	 * @return FileSource factory
 	 */
-	public static Factory<FileSource> fileSource(File file) {
+	public static Factory<FileSource> fileSource(java.io.File file) {
 		return context -> new FileSource(context).withPath(file);
 	}
 
@@ -173,7 +182,7 @@ public class CoreFactory {
 	 * @param dir the source directory
 	 * @return DirectorySource factory
 	 */
-	public static Factory<DirectorySource> directorySource(File dir) {
+	public static Factory<DirectorySource> directorySource(java.io.File dir) {
 		return context -> new DirectorySource(context).withPath(dir);
 	}
 

--- a/events/src/main/java/org/opentest4j/reporting/events/core/File.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/core/File.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.events.core;
+
+import org.opentest4j.reporting.events.api.ChildElement;
+import org.opentest4j.reporting.events.api.Context;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+
+import java.time.LocalDateTime;
+
+/**
+ * The {@code file} element of the core namespace.
+ */
+public class File extends ChildElement<Attachments, File> {
+
+	static final QualifiedName ELEMENT = QualifiedName.of(Namespace.REPORTING_CORE, "file");
+	private static final QualifiedName TIME = QualifiedName.of(Namespace.REPORTING_CORE, "time");
+	private static final QualifiedName PATH = QualifiedName.of(Namespace.REPORTING_CORE, "path");
+
+	File(Context context) {
+		super(context, ELEMENT);
+	}
+
+	/**
+	 * Set the {@code time} attribute of this element.
+	 *
+	 * @param timestamp the timestamp to set
+	 * @return this element
+	 */
+	public File withTime(LocalDateTime timestamp) {
+		withAttribute(TIME, timestamp.toString());
+		return this;
+	}
+
+	/**
+	 * Set the {@code path} attribute of this element.
+	 *
+	 * @param path the path to set
+	 * @return this element
+	 */
+	public File withPath(String path) {
+		withAttribute(PATH, path);
+		return this;
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.opentest4j.reporting
-version = 0.1.0-SNAPSHOT
+version = 0.2.0-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/schema/src/docs/asciidoc/includes/events.xml
+++ b/schema/src/docs/asciidoc/includes/events.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <e:events
-        xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0"
-        xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0">
+        xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0"
+        xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0">
     <infrastructure> <!--1-->
         <hostName>wonderland</hostName>
         <userName>alice</userName>

--- a/schema/src/docs/asciidoc/includes/hierarchy.xml
+++ b/schema/src/docs/asciidoc/includes/hierarchy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<h:execution xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0"
-             xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0">
+<h:execution xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.2.0"
+             xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0">
     <infrastructure> <!--1-->
         <hostName>wonderland</hostName>
         <userName>alice</userName>

--- a/schema/src/main/java/org/opentest4j/reporting/schema/Namespace.java
+++ b/schema/src/main/java/org/opentest4j/reporting/schema/Namespace.java
@@ -33,29 +33,29 @@ public class Namespace {
 	/**
 	 * Open Test Reporting core namespace
 	 */
-	public static final Namespace REPORTING_CORE = Namespace.of("https://schemas.opentest4j.org/reporting/core/0.1.0");
+	public static final Namespace REPORTING_CORE = Namespace.of("https://schemas.opentest4j.org/reporting/core/0.2.0");
 
 	/**
 	 * Open Test Reporting events namespace
 	 */
 	public static final Namespace REPORTING_EVENTS = Namespace.of(
-		"https://schemas.opentest4j.org/reporting/events/0.1.0");
+		"https://schemas.opentest4j.org/reporting/events/0.2.0");
 
 	/**
 	 * Open Test Reporting Java namespace
 	 */
-	public static final Namespace REPORTING_JAVA = Namespace.of("https://schemas.opentest4j.org/reporting/java/0.1.0");
+	public static final Namespace REPORTING_JAVA = Namespace.of("https://schemas.opentest4j.org/reporting/java/0.2.0");
 
 	/**
 	 * Open Test Reporting Git namespace
 	 */
-	public static final Namespace REPORTING_GIT = Namespace.of("https://schemas.opentest4j.org/reporting/git/0.1.0");
+	public static final Namespace REPORTING_GIT = Namespace.of("https://schemas.opentest4j.org/reporting/git/0.2.0");
 
 	/**
 	 * Open Test Reporting hierarchical namespace
 	 */
 	public static final Namespace REPORTING_HIERARCHY = Namespace.of(
-		"https://schemas.opentest4j.org/reporting/hierarchy/0.1.0");
+		"https://schemas.opentest4j.org/reporting/hierarchy/0.2.0");
 
 	/**
 	 * Create the namespace with the supplied URI.

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/core.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/core.xsd
@@ -1,6 +1,6 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.1.0"
-           targetNamespace="https://schemas.opentest4j.org/reporting/core/0.1.0"
+           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
+           targetNamespace="https://schemas.opentest4j.org/reporting/core/0.2.0"
            elementFormDefault="qualified">
   <xs:element name="infrastructure" type="core:Infrastructure"/>
   <xs:complexType name="Infrastructure">

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/core.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/core.xsd
@@ -51,23 +51,31 @@
       <xs:element name="attachments" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="data" minOccurs="0" maxOccurs="unbounded">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="entry" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:string">
-                          <xs:attribute name="key" type="xs:string" use="required"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="time" type="xs:dateTime" use="required"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="data">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="entry" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="key" type="xs:string" use="required"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="time" type="xs:dateTime" use="required"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="file">
+                <xs:complexType>
+                  <xs:attribute name="time" type="xs:dateTime" use="required"/>
+                  <xs:attribute name="path" type="xs:string" use="required"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:any namespace="##other"/>
+            </xs:choice>
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/events.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/events.xsd
@@ -1,9 +1,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.1.0"
-           xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0"
-           targetNamespace="https://schemas.opentest4j.org/reporting/events/0.1.0"
+           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
+           xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0"
+           targetNamespace="https://schemas.opentest4j.org/reporting/events/0.2.0"
            elementFormDefault="qualified">
-  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.1.0"/>
+  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.2.0"/>
   <xs:element name="events">
     <xs:complexType>
       <xs:sequence>

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
@@ -1,5 +1,5 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="https://schemas.opentest4j.org/reporting/git/0.1.0"
+           targetNamespace="https://schemas.opentest4j.org/reporting/git/0.2.0"
            elementFormDefault="qualified">
 
   <!-- infrastructure -->

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/hierarchy.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/hierarchy.xsd
@@ -1,9 +1,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0"
-           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.1.0"
-           targetNamespace="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0"
+           xmlns:h="https://schemas.opentest4j.org/reporting/hierarchy/0.2.0"
+           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
+           targetNamespace="https://schemas.opentest4j.org/reporting/hierarchy/0.2.0"
            elementFormDefault="qualified">
-  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.1.0"/>
+  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.2.0"/>
   <xs:element name="execution">
     <xs:complexType>
       <xs:sequence>

--- a/schema/src/main/resources/org/opentest4j/reporting/schema/java.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/java.xsd
@@ -1,9 +1,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.1.0"
-           targetNamespace="https://schemas.opentest4j.org/reporting/java/0.1.0"
+           xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
+           targetNamespace="https://schemas.opentest4j.org/reporting/java/0.2.0"
            elementFormDefault="qualified">
 
-  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.1.0"/>
+  <xs:import schemaLocation="core.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.2.0"/>
 
   <!-- infrastructure -->
   <xs:element name="javaVersion">

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
@@ -23,7 +23,6 @@ import org.opentest4j.reporting.events.root.Reported;
 import org.opentest4j.reporting.events.root.Started;
 import org.opentest4j.reporting.schema.Namespace;
 import org.opentest4j.reporting.schema.QualifiedName;
-import org.opentest4j.reporting.tooling.core.util.DomUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -50,6 +49,8 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI;
+import static org.opentest4j.reporting.tooling.core.util.DomUtils.matches;
+import static org.opentest4j.reporting.tooling.core.util.DomUtils.parseNamespace;
 import static org.opentest4j.reporting.tooling.core.util.DomUtils.stream;
 
 /**
@@ -104,23 +105,25 @@ public class DefaultConverter implements Converter {
 	 */
 	public Document convert(Node sourceRoot) throws Exception {
 		Document targetDocument = factory.newDocumentBuilder().newDocument();
-		createRootElement(sourceRoot, targetDocument);
+
+		var targetNamespace = determineTargetNamespace(sourceRoot);
+		createRootElement(sourceRoot, targetDocument, targetNamespace);
 
 		Map<String, Element> nodeById = new HashMap<>();
 
 		for (Node child = sourceRoot.getFirstChild(); child != null; child = child.getNextSibling()) {
 			if (child instanceof Element) {
 				Element element = (Element) child;
-				if (DomUtils.matches(Started.ELEMENT, element)) {
-					started(targetDocument, nodeById, element);
+				if (matches(Started.ELEMENT, element)) {
+					started(targetDocument, nodeById, element, targetNamespace);
 				}
-				else if (DomUtils.matches(Reported.ELEMENT, element)) {
+				else if (matches(Reported.ELEMENT, element)) {
 					reported(nodeById, element);
 				}
-				else if (DomUtils.matches(Finished.ELEMENT, element)) {
+				else if (matches(Finished.ELEMENT, element)) {
 					finished(nodeById, element);
 				}
-				else if (DomUtils.matches(Infrastructure.ELEMENT, element)) {
+				else if (matches(Infrastructure.ELEMENT, element)) {
 					infrastructure(targetDocument, element);
 				}
 			}
@@ -128,13 +131,19 @@ public class DefaultConverter implements Converter {
 		return targetDocument;
 	}
 
-	private void createRootElement(Node sourceRoot, Document targetDocument) {
+	private static Namespace determineTargetNamespace(Node sourceRoot) {
+		return parseNamespace(Namespace.REPORTING_HIERARCHY.getUri()).orElseThrow() //
+				.withVersion(parseNamespace(sourceRoot.getNamespaceURI()).orElseThrow().getVersion()) //
+				.toNamespace();
+	}
+
+	private void createRootElement(Node sourceRoot, Document targetDocument, Namespace targetNamespace) {
 		Element targetRoot = targetDocument.createElement(EXECUTION_NODE_NAME);
 		targetDocument.appendChild(targetRoot);
 
 		copyAttributes(sourceRoot, targetRoot, (__, value) -> !Namespace.REPORTING_EVENTS.getUri().equals(value));
 		targetRoot.setAttributeNS(XMLNS_ATTRIBUTE_NS_URI, XMLNS_ATTRIBUTE + ":" + HIERARCHY_PREFIX,
-			Namespace.REPORTING_HIERARCHY.getUri());
+			targetNamespace.getUri());
 	}
 
 	private void infrastructure(Document targetDocument, Element sourceElement) {
@@ -143,14 +152,15 @@ public class DefaultConverter implements Converter {
 		targetDocument.getDocumentElement().appendChild(targetElement);
 	}
 
-	private void started(Document targetDocument, Map<String, Element> nodeById, Element sourceElement) {
+	private void started(Document targetDocument, Map<String, Element> nodeById, Element sourceElement,
+			Namespace targetNamespace) {
 		Element targetElement;
 		if (sourceElement.hasAttribute(Started.PARENT_ID.getSimpleName())) {
-			targetElement = targetDocument.createElementNS(Namespace.REPORTING_HIERARCHY.getUri(), CHILD_NODE_NAME);
+			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), CHILD_NODE_NAME);
 			nodeById.get(sourceElement.getAttribute(Started.PARENT_ID.getSimpleName())).appendChild(targetElement);
 		}
 		else {
-			targetElement = targetDocument.createElementNS(Namespace.REPORTING_HIERARCHY.getUri(), ROOT_NODE_NAME);
+			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), ROOT_NODE_NAME);
 			targetDocument.getDocumentElement().appendChild(targetElement);
 		}
 

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -39,9 +39,7 @@ import java.util.function.BiConsumer;
 
 import static java.util.stream.Collectors.toList;
 import static org.joox.JOOX.$;
-import static org.joox.JOOX.and;
-import static org.joox.JOOX.namespaceURI;
-import static org.joox.JOOX.selector;
+import static org.opentest4j.reporting.tooling.core.util.DomUtils.matches;
 import static org.opentest4j.reporting.tooling.core.util.DomUtils.stream;
 
 /**
@@ -168,8 +166,7 @@ public class CoreContributor implements Contributor {
 	}
 
 	static Match findChild(Match march, QualifiedName elementName) {
-		return march.child(
-			and(namespaceURI(elementName.getNamespace().getUri()), selector(elementName.getSimpleName())));
+		return march.child(c -> matches(elementName, c.element()));
 	}
 
 	private static String capitalize(String value) {

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriter.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriter.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonSerializer;
 import org.opentest4j.reporting.events.core.Result;
 import org.opentest4j.reporting.events.root.Events;
 import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
 import org.opentest4j.reporting.tooling.core.converter.DefaultConverter;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Block;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
@@ -59,6 +60,9 @@ import static org.opentest4j.reporting.tooling.core.util.DomUtils.stream;
  * Default implementation of {@link HtmlReportWriter}.
  */
 public class DefaultHtmlReportWriter implements HtmlReportWriter {
+
+	private static final QualifiedName ROOT_ELEMENT = QualifiedName.of(Namespace.REPORTING_HIERARCHY, "root");
+	private static final QualifiedName CHILD_ELEMENT = QualifiedName.of(Namespace.REPORTING_HIERARCHY, "child");
 
 	private final ServiceLoader<Contributor> contributors = ServiceLoader.load(Contributor.class);
 
@@ -115,8 +119,7 @@ public class DefaultHtmlReportWriter implements HtmlReportWriter {
 		addSections(rootElement, execution);
 
 		for (Node child = rootElement.getFirstChild(); child != null; child = child.getNextSibling()) {
-			if (child instanceof Element && Namespace.REPORTING_HIERARCHY.getUri().equals(child.getNamespaceURI())
-					&& "root".equals(child.getLocalName())) {
+			if (child instanceof Element && matches(ROOT_ELEMENT, (Element) child)) {
 				var root = visitNode((Element) child, idGenerator, new ArrayDeque<>(), execution);
 				execution.durationMillis += root.durationMillis;
 				execution.roots.add(root.id);
@@ -181,8 +184,7 @@ public class DefaultHtmlReportWriter implements HtmlReportWriter {
 		}
 		parentIds.push(currentId);
 		for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
-			if (child instanceof Element && Namespace.REPORTING_HIERARCHY.getUri().equals(child.getNamespaceURI())
-					&& "child".equals(child.getLocalName())) {
+			if (child instanceof Element && matches(CHILD_ELEMENT, (Element) child)) {
 				visitNode((Element) child, idGenerator, parentIds, execution);
 			}
 		}

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/util/DomUtils.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/util/DomUtils.java
@@ -16,13 +16,18 @@
 
 package org.opentest4j.reporting.tooling.core.util;
 
+import org.opentest4j.reporting.schema.Namespace;
 import org.opentest4j.reporting.schema.QualifiedName;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.IntFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -30,6 +35,8 @@ import java.util.stream.Stream;
  * Internal utils to work with DOM types
  */
 public class DomUtils {
+
+	private static final Pattern NAMESPACE_VERSION_PATTERN = Pattern.compile("^(.+)/([0-9.]+)$");
 
 	private DomUtils() {
 	}
@@ -59,15 +66,131 @@ public class DomUtils {
 	}
 
 	/**
-	 * Check whether the simple name and namespace of the supplied element
-	 * match the supplied qualified name.
+	 * Check whether the simple name of the supplied element matches the
+	 * supplied qualified name and the namespace of the element is compatible
+	 * with the namespace of the qualified name (same base URI and version less
+	 * than or equal to the version of the qualified name).
 	 *
 	 * @param qualifiedName the qualified name to match
 	 * @param element the element to check
 	 * @return {@code true} if the element matches the qualified name
 	 */
 	public static boolean matches(QualifiedName qualifiedName, Element element) {
-		return qualifiedName.getNamespace().getUri().equals(element.getNamespaceURI())
+		return isNamespaceCompatible(qualifiedName, element)
 				&& qualifiedName.getSimpleName().equals(element.getLocalName());
+	}
+
+	private static boolean isNamespaceCompatible(QualifiedName qualifiedName, Element element) {
+		return parseNamespace(qualifiedName.getNamespace().getUri()) //
+				.flatMap(expected -> parseNamespace(element.getNamespaceURI()).filter(expected::isCompatible)) //
+				.isPresent();
+	}
+
+	/**
+	 * Parse the supplied namespace URI into a base URI and a version.
+	 *
+	 * @param namespaceUri the namespace URI to parse
+	 * @return the versioned namespace
+	 */
+	public static Optional<VersionedNamespace> parseNamespace(String namespaceUri) {
+		return Optional.ofNullable(namespaceUri) //
+				.map(NAMESPACE_VERSION_PATTERN::matcher) //
+				.filter(Matcher::matches) //
+				.map(it -> new VersionedNamespace(it.group(1), NamespaceVersion.parse(it.group(2))));
+	}
+
+	/**
+	 * A namespace base URI and version.
+	 */
+	public static class VersionedNamespace {
+
+		private final String baseUri;
+		private final NamespaceVersion version;
+
+		VersionedNamespace(String baseUri, NamespaceVersion version) {
+			this.baseUri = baseUri;
+			this.version = version;
+		}
+
+		/**
+		 * {@return the base URI}
+		 */
+		public String getBaseUri() {
+			return baseUri;
+		}
+
+		/**
+		 * {@return the version}
+		 */
+		public NamespaceVersion getVersion() {
+			return version;
+		}
+
+		boolean isCompatible(VersionedNamespace that) {
+			return this.getBaseUri().equals(that.getBaseUri()) //
+					&& that.getVersion().compareTo(this.getVersion()) <= 0;
+		}
+
+		/**
+		 * Create a new versioned namespace with the supplied version.
+		 *
+		 * @param version the version
+		 * @return the new versioned namespace
+		 */
+		public VersionedNamespace withVersion(NamespaceVersion version) {
+			return new VersionedNamespace(getBaseUri(), version);
+		}
+
+		/**
+		 * Convert this versioned namespace to a namespace.
+		 *
+		 * @return the namespace
+		 */
+		public Namespace toNamespace() {
+			return Namespace.of(getBaseUri() + "/" + getVersion());
+		}
+	}
+
+	/**
+	 * Represents a namespace version.
+	 */
+	public static class NamespaceVersion implements Comparable<NamespaceVersion> {
+
+		/**
+		 * Parse the supplied version string.
+		 *
+		 * @param version the version string to parse
+		 * @return the parsed version
+		 */
+		public static NamespaceVersion parse(String version) {
+			var parts = Arrays.stream(version.split("\\.")) //
+					.mapToInt(Integer::parseInt) //
+					.toArray();
+			return new NamespaceVersion(version, parts);
+		}
+
+		private final String stringValue;
+		private final int[] parts;
+
+		NamespaceVersion(String stringValue, int[] parts) {
+			this.stringValue = stringValue;
+			this.parts = parts;
+		}
+
+		@Override
+		public int compareTo(NamespaceVersion that) {
+			for (int i = 0; i < Math.min(this.parts.length, that.parts.length); i++) {
+				int comparison = Integer.compare(this.parts[i], that.parts[i]);
+				if (comparison != 0) {
+					return comparison;
+				}
+			}
+			return Integer.compare(this.parts.length, that.parts.length);
+		}
+
+		@Override
+		public String toString() {
+			return stringValue;
+		}
 	}
 }

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
@@ -24,10 +24,13 @@ import org.opentest4j.reporting.events.api.DocumentWriter;
 import org.opentest4j.reporting.events.api.NamespaceRegistry;
 import org.opentest4j.reporting.events.root.Events;
 import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.tooling.core.util.DomUtils;
+import org.opentest4j.reporting.tooling.core.util.DomUtils.NamespaceVersion;
 import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -56,6 +59,9 @@ class DefaultConverterTests {
 			.add("java", Namespace.REPORTING_JAVA) //
 			.build();
 
+	static final NamespaceVersion CURRENT_VERSION = DomUtils.parseNamespace(
+		Namespace.REPORTING_HIERARCHY.getUri()).orElseThrow().getVersion();
+
 	Path sourceFile;
 	Path targetFile;
 
@@ -72,7 +78,7 @@ class DefaultConverterTests {
 
 		new DefaultConverter().convert(sourceFile, targetFile);
 
-		assertAll(targetFile, it -> it.valueByXPath("//*/c:infrastructure/c:cpuCores").isEqualTo(42));
+		assertAll(targetFile, CURRENT_VERSION, it -> it.valueByXPath("//*/c:infrastructure/c:cpuCores").isEqualTo(42));
 	}
 
 	@Test
@@ -91,7 +97,7 @@ class DefaultConverterTests {
 
 		new DefaultConverter().convert(sourceFile, targetFile);
 
-		assertAll(targetFile, //
+		assertAll(targetFile, CURRENT_VERSION, //
 			it -> it.nodesByXPath("//*/h:root") //
 					.hasSize(1) //
 					.haveAttribute("name", "container") //
@@ -123,7 +129,7 @@ class DefaultConverterTests {
 
 		new DefaultConverter().convert(sourceFile, targetFile);
 
-		assertAll(targetFile, //
+		assertAll(targetFile, CURRENT_VERSION, //
 			it -> it.nodesByXPath("//*/h:root/c:attachments").hasSize(1), //
 			it -> it.nodesByXPath("//*/h:root/c:attachments/c:data").hasSize(3), //
 			it -> it.valueByXPath("(//*/h:root/c:attachments/c:data/c:entry/@key)[1]").isEqualTo("started"), //
@@ -135,6 +141,24 @@ class DefaultConverterTests {
 		);
 	}
 
+	@Test
+	void convertsOldVersions() throws Exception {
+		Files.writeString(sourceFile,
+			"""
+					<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0">
+					  <infrastructure>
+					    <cpuCores>42</cpuCores>
+					  </infrastructure>
+					</e:events>
+					""");
+
+		new DefaultConverter().convert(sourceFile, targetFile);
+
+		assertAll(targetFile, NamespaceVersion.parse("0.1.0"), //
+			it -> it.nodesByXPath("//h:execution").hasSize(1), //
+			it -> it.valueByXPath("//*/c:infrastructure/c:cpuCores").isEqualTo(42));
+	}
+
 	private void writeXml(Path eventsXmlFile, Consumer<DocumentWriter<Events>> action) throws Exception {
 		try (var writer = Events.createDocumentWriter(NAMESPACE_REGISTRY, eventsXmlFile)) {
 			action.accept(writer);
@@ -142,14 +166,18 @@ class DefaultConverterTests {
 	}
 
 	@SafeVarargs
-	private static void assertAll(Path targetFile, Consumer<XmlAssert>... checks) {
+	private static void assertAll(Path targetFile, NamespaceVersion version, Consumer<XmlAssert>... checks) {
 		var document = Convert.toDocument(Input.from(targetFile).build());
 		var xmlAssert = XmlAssert.assertThat(document).withNamespaceContext(Map.of( //
-			"h", Namespace.REPORTING_HIERARCHY.getUri(), //
-			"c", Namespace.REPORTING_CORE.getUri() //
+			"h", toNamespaceUri(Namespace.REPORTING_HIERARCHY, version), //
+			"c", toNamespaceUri(Namespace.REPORTING_CORE, version) //
 		));
 		Assertions.assertAll(targetFile.toUri().toString(),
 			Arrays.stream(checks).map(it -> () -> it.accept(xmlAssert)));
+	}
+
+	private static String toNamespaceUri(Namespace namespace, NamespaceVersion version) {
+		return DomUtils.parseNamespace(namespace.getUri()).orElseThrow().withVersion(version).toNamespace().getUri();
 	}
 
 }

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/util/DomUtilsTest.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/util/DomUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.tooling.core.util;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.QualifiedName;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DomUtilsTest {
+
+	@Test
+	void matchesCompatibleNamespaces() {
+		assertAll( //
+			() -> assertTrue(DomUtils.matches(QualifiedName.of(Namespace.of("https://foo/1.2.3"), "a"),
+				element("https://foo/1.2", "a"))), //
+			() -> assertTrue(DomUtils.matches(QualifiedName.of(Namespace.of("https://foo/1.2.3"), "a"),
+				element("https://foo/1.2.3", "a"))), //
+			() -> assertFalse(DomUtils.matches(QualifiedName.of(Namespace.of("https://foo/1.2.3"), "a"),
+				element("https://foo/1.2.3", "b"))), //
+			() -> assertFalse(DomUtils.matches(QualifiedName.of(Namespace.of("https://foo/1.2.3"), "a"),
+				element("https://foo/1.2.4", "a"))), //
+			() -> assertFalse(DomUtils.matches(QualifiedName.of(Namespace.of("https://foo/1.2.3"), "a"),
+				element("https://bar/1.2.3", "a"))) //
+		);
+	}
+
+	private static Element element(String namespaceURI, String qualifiedName) throws ParserConfigurationException {
+		return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument().createElementNS(namespaceURI,
+			qualifiedName);
+	}
+}

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidatorTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidatorTests.java
@@ -37,7 +37,7 @@ class DefaultValidatorTests {
 	@Test
 	void validatesEventsXmlFile() {
 		var xmlFile = writeXml(tempDir.resolve("events.xml"), """
-				<events xmlns="https://schemas.opentest4j.org/reporting/events/0.1.0"/>
+				<events xmlns="https://schemas.opentest4j.org/reporting/events/0.2.0"/>
 				""");
 
 		var validationResult = new DefaultValidator().validate(xmlFile);
@@ -48,7 +48,7 @@ class DefaultValidatorTests {
 	@Test
 	void validatesHierarchicalXmlFile() {
 		var xmlFile = writeXml(tempDir.resolve("hierarchy.xml"), """
-				<execution xmlns="https://schemas.opentest4j.org/reporting/hierarchy/0.1.0"/>
+				<execution xmlns="https://schemas.opentest4j.org/reporting/hierarchy/0.2.0"/>
 				""");
 
 		var validationResult = new DefaultValidator().validate(xmlFile);


### PR DESCRIPTION
This allows testing frameworks to attach files (screenshots, log files, etc.) to tests to help reason about the test outcome.

Resolves #3.