### PR TITLE
Allow Git URLs without a specified schema

### DIFF
--- a/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
+++ b/schema/src/main/resources/org/opentest4j/reporting/schema/git.xsd
@@ -6,10 +6,19 @@
 
   <xs:element name="repository">
     <xs:complexType>
-      <xs:attribute name="originUrl" type="xs:anyURI" use="required">
+      <xs:attribute name="originUrl" use="required">
         <xs:annotation>
           <xs:documentation>the URL of the 'origin' remote of the Git repository</xs:documentation>
         </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="xs:anyURI">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value=".*:.*"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
       </xs:attribute>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
the git.xsd only allows xs:anyURI values for the git origin url, but the default ssh-git clone url from github doesn't specify the ssh://-schema and is not a valid URI