### PR TITLE
Only install Playwright dependencies when running tests

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -43,5 +43,4 @@ runs:
         -PopenTestReporting.nodeDownload=false \
         --refresh-dependencies \
         javaToolchains \
-        installPlaywrightDeps \
         ${{ inputs.arguments }}


### PR DESCRIPTION
If the test task is FROM-CACHE, there's no need to install Playwright
dependencies.
