### PR TITLE
Gradle build cache improvements

### DIFF
--- a/buildSrc/src/main/kotlin/java-basics.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-basics.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    `java-library`
+}
+
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Bnd-LastModified")
+            ignoreAttribute("Created-By")
+            ignoreAttribute("Tool")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -2,9 +2,9 @@ import org.gradle.api.tasks.PathSensitivity.NONE
 import java.nio.file.Files
 
 plugins {
-    `java-library`
     id("biz.aQute.bnd.builder")
     id("com.diffplug.spotless")
+    id("java-basics")
     id("publishing-conventions")
 }
 

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -106,6 +106,8 @@ tasks {
         argumentProviders += CommandLineArgumentProvider {
             listOf(eventXmlFiles.singleFile.absolutePath)
         }
+        outputs.files(provider { eventXmlFiles.firstOrNull()?.resolveSibling("hierarchy.xml") })
+        outputs.cacheIf { true }
     }
 
     val generateHtmlReport by registering(JavaExec::class) {
@@ -117,6 +119,8 @@ tasks {
         argumentProviders += CommandLineArgumentProvider {
             listOf(eventXmlFiles.singleFile.absolutePath)
         }
+        outputs.files(provider { eventXmlFiles.firstOrNull()?.let { xmlFile -> xmlFile.resolveSibling(xmlFile.nameWithoutExtension + ".html") } })
+        outputs.cacheIf { true }
     }
 
     withType<Test>().configureEach {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     `java-conventions`
-    application
     alias(libs.plugins.shadow)
-}
-
-application {
-    applicationName = "open-test-reporting"
-    mainClass = "org.opentest4j.reporting.cli.ReportingCli"
 }
 
 dependencies {
@@ -23,7 +17,7 @@ tasks {
     }
     jar {
         manifest {
-            attributes("Main-Class" to application.mainClass)
+            attributes("Main-Class" to "org.opentest4j.reporting.cli.ReportingCli")
         }
     }
     shadowJar {

--- a/html-report/build.gradle.kts
+++ b/html-report/build.gradle.kts
@@ -18,6 +18,7 @@ val buildVueDist by tasks.registering(NpmTask::class) {
         include("public/**", "src/**", "*.html", "*.js", "*.json", "*.ts")
     })
     outputs.file(node.nodeProjectDir.file("dist/index.html"))
+    outputs.cacheIf { true }
     npmCommand.addAll("run", "build")
 }
 

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.PathSensitivity.NONE
 import java.nio.file.Files
 
 plugins {
-    `java-library`
+    `java-basics`
 }
 
 val cli by configurations.dependencyScope("cli")

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -42,6 +42,8 @@ tasks {
         argumentProviders += CommandLineArgumentProvider {
             listOf(eventXmlFiles.singleFile.absolutePath)
         }
+        outputs.files(provider { eventXmlFiles.firstOrNull()?.resolveSibling("hierarchy.xml") })
+        outputs.cacheIf { true }
     }
 
     val generateHtmlReport by registering(JavaExec::class) {
@@ -56,6 +58,8 @@ tasks {
                 htmlReportFile.get().asFile.absolutePath
             ) + eventXmlFiles.files.map { it.absolutePath }.toList()
         }
+        outputs.files(provider { eventXmlFiles.firstOrNull()?.let { xmlFile -> xmlFile.resolveSibling(xmlFile.nameWithoutExtension + ".html") } })
+        outputs.cacheIf { true }
     }
 
     configurations.consumable("htmlReport") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,10 +17,10 @@ dependencyResolutionManagement {
     }
 }
 
+val isCiServer = System.getenv("CI") != null
+
 develocity {
     buildScan {
-        val isCiServer = System.getenv("CI") != null
-
         server = "https://ge.junit.org"
         uploadInBackground = !isCiServer
 
@@ -34,6 +34,16 @@ develocity {
         }
 
         publishing.onlyIf { it.isAuthenticated }
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = !isCiServer
+    }
+    remote(develocity.buildCache) {
+        val authenticated = System.getenv("DEVELOCITY_ACCESS_KEY") != null
+        isPush = isCiServer && authenticated
     }
 }
 


### PR DESCRIPTION
- **Remove unused application plugin**
- **Ignore manifest attributes that may change between builds/machines**
- **Make XML conversion and HTML report tasks cacheable**
- **Enable remote build cache**
