### PR TITLE
Revert "Update dependency org.eclipse.platform:org.eclipse.platform to v4.34.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-eclipse = "4.34.0"
+eclipse = "4.32.0"
 immutables = "2.10.1"
 playwright = "1.49.0"
 


### PR DESCRIPTION
Reverts ota4j-team/open-test-reporting#210 which caused build failures