### PR TITLE
Fix whitespace handling

### DIFF
--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -135,6 +135,7 @@ public class CoreContributor implements Contributor {
 		var children = findChild(element, Sources.ELEMENT) //
 				.map(DomUtils::children) //
 				.orElseGet(Stream::empty) //
+				.filter(Element.class::isInstance) //
 				.toList();
 
 		if (children.isEmpty()) {

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -180,6 +180,7 @@ public class CoreContributor implements Contributor {
 		var children = findChild(context.element(), Attachments.ELEMENT) //
 				.map(DomUtils::children) //
 				.orElseGet(Stream::empty) //
+				.filter(Element.class::isInstance) //
 				.toList();
 		if (children.isEmpty()) {
 			return Optional.empty();

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterBrowserTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterBrowserTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @UsePlaywright
 @ExtendWith(PlaywrightTracePublisher.class)
-class DefaultHtmlReportWriterTests {
+class DefaultHtmlReportWriterBrowserTests {
 
 	@TempDir
 	static Path tempDir;

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterTests.java
@@ -49,4 +49,27 @@ class DefaultHtmlReportWriterTests {
 		var writer = new DefaultHtmlReportWriter();
 		assertDoesNotThrow(() -> writer.writeHtmlReport(List.of(xmlFile), tempDir.resolve("report.html")));
 	}
+
+	@Test // https://github.com/ota4j-team/open-test-reporting/issues/294
+	void canHandleWhitespaceInAttachments(@TempDir Path tempDir) throws Exception {
+		@Language("xml")
+		var xml = """
+				<?xml version="1.0" encoding="utf-8"?>
+				<e:events xmlns:c="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0">
+				    <e:started id="1" name="SomeTest" time="2025-01-31T13:52:41.404Z"/>
+				    <e:reported id="1" time="2025-01-31T14:22:15.608Z">
+				        <c:attachments>
+				            <c:output source="stdout" time="2025-01-31T14:22:15.608Z">someOutput</c:output>
+				        </c:attachments>
+				    </e:reported>
+				    <e:finished id="1" time="2025-01-31T13:52:41.608Z">
+				        <c:result status="SUCCESSFUL"/>
+				    </e:finished>
+				</e:events>
+				""";
+		var xmlFile = Files.writeString(tempDir.resolve("report.xml"), xml);
+
+		var writer = new DefaultHtmlReportWriter();
+		assertDoesNotThrow(() -> writer.writeHtmlReport(List.of(xmlFile), tempDir.resolve("report.html")));
+	}
 }

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.tooling.core.htmlreport;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DefaultHtmlReportWriterTests {
+
+	@Test // https://github.com/ota4j-team/open-test-reporting/issues/293
+	void canHandleWhitespaceInSources(@TempDir Path tempDir) throws Exception {
+		@Language("xml")
+		var xml = """
+				<?xml version="1.0" encoding="utf-8"?>
+				<e:events xmlns:c="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0">
+				    <e:started id="1" name="SomeTest" time="2025-01-31T13:52:41.404Z">
+				        <c:sources>
+				            <c:fileSource path="./some/file"/>
+				        </c:sources>
+				    </e:started>
+				    <e:finished id="1" time="2025-01-31T13:52:41.608Z">
+				        <c:result status="SUCCESSFUL"/>
+				    </e:finished>
+				</e:events>
+				""";
+		var xmlFile = Files.writeString(tempDir.resolve("report.xml"), xml);
+
+		var writer = new DefaultHtmlReportWriter();
+		assertDoesNotThrow(() -> writer.writeHtmlReport(List.of(xmlFile), tempDir.resolve("report.html")));
+	}
+}


### PR DESCRIPTION
- **Rename to `*BrowserTest` to differentiate from unit tests**
- **Handle whitespace in `<sources>`**
- **Handle whitespace in `<attachments>`**

Fixes #293.
Fixes #294.