### PR TITLE
Fix writing events using Saxon

### DIFF
--- a/events/build.gradle.kts
+++ b/events/build.gradle.kts
@@ -8,6 +8,12 @@ val woodstoxRuntimeClasspath = configurations.resolvable("woodstoxRuntimeClasspa
     extendsFrom(woodstox.get())
 }
 
+val saxon = configurations.dependencyScope("saxon")
+val saxonRuntimeClasspath = configurations.resolvable("saxonRuntimeClasspath") {
+    extendsFrom(configurations.testRuntimeClasspath.get())
+    extendsFrom(saxon.get())
+}
+
 dependencies {
     api(projects.schema)
     compileOnlyApi(libs.apiguardian)
@@ -17,6 +23,7 @@ dependencies {
     testImplementation(libs.xmlunit.assertj)
     testCompileOnly(libs.jetbrains.annotations)
     woodstox(libs.woodstox.core)
+    saxon(libs.saxon)
 }
 
 tasks {
@@ -26,7 +33,13 @@ tasks {
         classpath = files(sourceSets.main.map { it.output }) + files(test.map { it.sources.output }) + woodstoxRuntimeClasspath.get()
         group = JavaBasePlugin.VERIFICATION_GROUP
     }
+    val testSaxon by registering(Test::class) {
+        val test by testing.suites.existing(JvmTestSuite::class)
+        testClassesDirs = files(test.map { it.sources.output.classesDirs })
+        classpath = files(sourceSets.main.map { it.output }) + files(test.map { it.sources.output }) + saxonRuntimeClasspath.get()
+        group = JavaBasePlugin.VERIFICATION_GROUP
+    }
     check {
-        dependsOn(testWoodstox)
+        dependsOn(testWoodstox, testSaxon)
     }
 }

--- a/events/src/main/java/org/opentest4j/reporting/events/api/SingleElementXMLStreamWriter.java
+++ b/events/src/main/java/org/opentest4j/reporting/events/api/SingleElementXMLStreamWriter.java
@@ -70,8 +70,8 @@ class SingleElementXMLStreamWriter implements XMLStreamWriter {
 	}
 
 	@Override
-	public void close() throws XMLStreamException {
-		delegate.close();
+	public void close() {
+		// do not forward close to prevent closing the underlying writer too early
 	}
 
 	@Override

--- a/events/src/test/java/org/opentest4j/reporting/events/api/DocumentWriterTest.java
+++ b/events/src/test/java/org/opentest4j/reporting/events/api/DocumentWriterTest.java
@@ -79,16 +79,6 @@ class DocumentWriterTest {
 					.withCDataSection(message));
 		}
 
-		System.out.println(Files.readString(targetFile));
-
-		@Language("xml")
-		var expected = """
-				<root xmlns="urn::a">
-				    <child a="&lt;foo&gt;&lt;![CDATA[bar]]&gt;&lt;/foo&gt;"><![CDATA[<foo><![CDATA[bar]]]]><![CDATA[></foo>]]></child>
-				</root>
-				""";
-
-		assertThat(targetFile).and(expected).ignoreWhitespace().areIdentical();
 		assertThat(targetFile).withNamespaceContext(Map.of("a", "urn::a")) //
 				.valueByXPath("//a:child").isEqualTo(message);
 		assertThat(targetFile).withNamespaceContext(Map.of("a", "urn::a")) //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporti
 log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version = "2.24.3" }
 picocli = { module = "info.picocli:picocli", version = "4.7.6" }
 playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
+saxon = { module = "net.sf.saxon:Saxon-HE", version = "12.5" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version = "2.0.16" }
 xmlunit-assertj = { module = "org.xmlunit:xmlunit-assertj3", version = "2.10.0" }
 woodstox-core = { module = "com.fasterxml.woodstox:woodstox-core", version = "7.1.0" }


### PR DESCRIPTION
- **Add Saxon test task**
- **Relax assertion because Saxon handles CDATA differently but correctly**
- **Avoid closing the underlying `XMLStreamWriter` too early**

Fixes #315.
