### PR TITLE
Fix NPE on MacOS when target HTML is a relative path

### DIFF
--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/htmlreport/CoreContributor.java
@@ -300,6 +300,10 @@ public class CoreContributor implements Contributor {
 	}
 
 	private static Path tryRelativize(Path parent, Path path) {
+		if (parent == null) {
+			// This can happen on Mac when the target is a local path
+			return path;
+		}
 		try {
 			return parent.relativize(path);
 		}


### PR DESCRIPTION
I was in the process of creating an example using GitHub Actions and multi modules. My work in progress example is at https://github.com/filiphr/open-test-reporting-sample.

I am not sure how to write a test case for it. However, it can be reproduced in the example project by running

```sh
./mvnw verify --fail-at-end
```

and then running:

```sh
jbang org.opentest4j.reporting:open-test-reporting-cli:0.2.0:standalone html-report --output open-test-report.html module-a/target/surefire-reports/open-test-report.xml module-b/target/surefire-reports/open-test-report.xml     
```

The exception stacktrace is:

```
java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.relativize(java.nio.file.Path)" because "parent" is null
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.tryRelativize(CoreContributor.java:304)
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.lambda$addFileAttachment$16(CoreContributor.java:216)
        at java.base/java.util.Optional.ifPresent(Optional.java:178)
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.addFileAttachment(CoreContributor.java:212)
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.lambda$createAttachmentsSection$14(CoreContributor.java:194)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.createAttachmentsSection(CoreContributor.java:203)
        at org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor.contributeSectionsForTestNode(CoreContributor.java:104)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.lambda$contributeSections$9(DefaultHtmlReportWriter.java:252)
        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.contributeSections(DefaultHtmlReportWriter.java:253)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.addSections(DefaultHtmlReportWriter.java:246)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.visitNode(DefaultHtmlReportWriter.java:218)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.visitNode(DefaultHtmlReportWriter.java:229)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.visitNode(DefaultHtmlReportWriter.java:229)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.extractData(DefaultHtmlReportWriter.java:197)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.extractData(DefaultHtmlReportWriter.java:118)
        at org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter.writeHtmlReport(DefaultHtmlReportWriter.java:92)
        at org.opentest4j.reporting.cli.HtmlReportCommand.call(HtmlReportCommand.java:69)
        at org.opentest4j.reporting.cli.HtmlReportCommand.call(HtmlReportCommand.java:39)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.opentest4j.reporting.cli.ReportingCli.main(ReportingCli.java:52)
```

This is happening with

```
openjdk version "21.0.3" 2024-04-16 LTS
OpenJDK Runtime Environment Temurin-21.0.3+9 (build 21.0.3+9-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.3+9 (build 21.0.3+9-LTS, mixed mode)
```