### PR TITLE
Simplify running `org.opentest4j.reporting.cli` on the module path

### DIFF
--- a/buildSrc/src/main/kotlin/UpdateJarAction.kt
+++ b/buildSrc/src/main/kotlin/UpdateJarAction.kt
@@ -1,0 +1,44 @@
+import org.gradle.api.Action
+import org.gradle.api.Task
+import org.gradle.api.internal.file.archive.ZipEntryConstants
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.process.ExecOperations
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import javax.inject.Inject
+
+abstract class UpdateJarAction @Inject constructor(private val operations: ExecOperations): Action<Task> {
+
+    companion object {
+        // Since ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES is in the default time zone (see its Javadoc),
+        // we're converting it to the same time in UTC here to make the jar reproducible regardless of the
+        // build's time zone.
+        private val CONSTANT_TIME_FOR_ZIP_ENTRIES = LocalDateTime.ofInstant(Instant.ofEpochMilli(ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES), ZoneId.systemDefault())
+            .toInstant(ZoneOffset.UTC)
+            .toString()
+    }
+
+    abstract val javaLauncher: Property<JavaLauncher>
+
+    abstract val args: ListProperty<String>
+
+    init {
+        args.addAll(
+            "--update",
+            // Use a constant time to make the JAR reproducible.
+            "--date=$CONSTANT_TIME_FOR_ZIP_ENTRIES",
+        )
+    }
+
+    override fun execute(t: Task) {
+        operations.exec {
+            executable = javaLauncher.get()
+                .metadata.installationPath.file("bin/jar").asFile.absolutePath
+            args = this@UpdateJarAction.args.get()
+        }
+    }
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -12,27 +12,32 @@ dependencies {
     runtimeOnly(libs.log4j.slf4j2.impl)
 }
 
+val mainClass = "org.opentest4j.reporting.cli.ReportingCli"
+
 tasks {
     compileJava {
         options.release = 21
     }
     jar {
-        manifest {
-            attributes("Main-Class" to "org.opentest4j.reporting.cli.ReportingCli")
-        }
         doLast(objects.newInstance(UpdateJarAction::class).apply {
             javaLauncher = project.javaToolchains.launcherFor(java.toolchain)
             args.addAll(
                 "--file", archiveFile.get().asFile.absolutePath,
-                "--main-class", "org.opentest4j.reporting.cli.ReportingCli",
+                "--main-class", mainClass,
             )
         })
     }
     shadowJar {
+        manifest {
+            attributes("Main-Class" to mainClass)
+        }
         archiveClassifier = "standalone"
         exclude("META-INF/maven/**")
         exclude("META-INF/LICENSE*")
         exclude("META-INF/NOTICE*")
         exclude("**/module-info.class")
+    }
+    assemble {
+        dependsOn(shadowJar)
     }
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -15,12 +15,18 @@ dependencies {
 tasks {
     compileJava {
         options.release = 21
-        options.javaModuleMainClass = "org.opentest4j.reporting.cli.ReportingCli"
     }
     jar {
         manifest {
             attributes("Main-Class" to "org.opentest4j.reporting.cli.ReportingCli")
         }
+        doLast(objects.newInstance(UpdateJarAction::class).apply {
+            javaLauncher = project.javaToolchains.launcherFor(java.toolchain)
+            args.addAll(
+                "--file", archiveFile.get().asFile.absolutePath,
+                "--main-class", "org.opentest4j.reporting.cli.ReportingCli",
+            )
+        })
     }
     shadowJar {
         archiveClassifier = "standalone"

--- a/cli/src/module/java/org.opentest4j.reporting.cli/module-info.java
+++ b/cli/src/module/java/org.opentest4j.reporting.cli/module-info.java
@@ -29,4 +29,6 @@ module org.opentest4j.reporting.cli {
     requires org.slf4j;
 
     exports org.opentest4j.reporting.cli;
+
+    opens org.opentest4j.reporting.cli to info.picocli;
 }

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -40,7 +40,8 @@ tasks {
         test.map { it.reports.junitXml.outputLocation.get().file("open-test-report.xml") }
 
     val convertTestResultXmlToHierarchicalFormat by registering(JavaExec::class) {
-        mainClass.set("org.opentest4j.reporting.cli.ReportingCli")
+        mainModule = "org.opentest4j.reporting.cli"
+        modularity.inferModulePath = true
         args("convert")
         classpath(cliClasspath)
         inputs.file(eventXmlFile).withPathSensitivity(NONE).skipWhenEmpty()

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.PathSensitivity.NONE
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import java.nio.file.Files
 
 plugins {
@@ -58,7 +59,7 @@ tasks {
         args("html-report")
         classpath(cliClasspath)
         outputs.file(htmlReportFile)
-        inputs.files(eventXmlFile).withPathSensitivity(NONE).skipWhenEmpty()
+        inputs.files(eventXmlFile).withPathSensitivity(RELATIVE).skipWhenEmpty()
         argumentProviders += CommandLineArgumentProvider {
             listOf(
                 "--output",

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -53,6 +53,17 @@ tasks {
         outputs.cacheIf { true }
     }
 
+    val validateTestResultXml by registering(JavaExec::class) {
+        mainModule = "org.opentest4j.reporting.cli"
+        modularity.inferModulePath = true
+        args("validate")
+        classpath(cliClasspath)
+        inputs.file(eventXmlFile).withPathSensitivity(NONE).skipWhenEmpty()
+        argumentProviders += CommandLineArgumentProvider {
+            listOf(eventXmlFile.get().asFile.absolutePath)
+        }
+    }
+
     val generateHtmlReport by registering(JavaExec::class) {
         mainModule = "org.opentest4j.reporting.cli"
         modularity.inferModulePath = true
@@ -100,6 +111,6 @@ tasks {
             }
         }
 
-        finalizedBy(convertTestResultXmlToHierarchicalFormat, generateHtmlReport)
+        finalizedBy(validateTestResultXml, convertTestResultXmlToHierarchicalFormat, generateHtmlReport)
     }
 }

--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -52,7 +52,8 @@ tasks {
     }
 
     val generateHtmlReport by registering(JavaExec::class) {
-        mainClass.set("org.opentest4j.reporting.cli.ReportingCli")
+        mainModule = "org.opentest4j.reporting.cli"
+        modularity.inferModulePath = true
         args("html-report")
         classpath(cliClasspath)
         outputs.file(htmlReportFile)

--- a/schema/src/main/java/org/opentest4j/reporting/schema/Schemas.java
+++ b/schema/src/main/java/org/opentest4j/reporting/schema/Schemas.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j.reporting.schema;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Utility class for retrieving schema locations.
+ *
+ * @since 0.2.2
+ */
+public final class Schemas {
+
+	private static final Map<Namespace, String> SCHEMAS;
+
+	static {
+		Map<Namespace, String> schemas = new HashMap<>();
+		schemas.put(Namespace.REPORTING_EVENTS_0_1_0, "/org/opentest4j/reporting/schema/events-0.1.0.xsd");
+		schemas.put(Namespace.REPORTING_HIERARCHY_0_1_0, "/org/opentest4j/reporting/schema/hierarchy-0.1.0.xsd");
+		schemas.put(Namespace.REPORTING_CORE_0_1_0, "/org/opentest4j/reporting/schema/core-0.1.0.xsd");
+		schemas.put(Namespace.REPORTING_JAVA_0_1_0, "/org/opentest4j/reporting/schema/java-0.1.0.xsd");
+		schemas.put(Namespace.REPORTING_EVENTS_0_2_0, "/org/opentest4j/reporting/schema/events-0.2.0.xsd");
+		schemas.put(Namespace.REPORTING_HIERARCHY_0_2_0, "/org/opentest4j/reporting/schema/hierarchy-0.2.0.xsd");
+		schemas.put(Namespace.REPORTING_CORE_0_2_0, "/org/opentest4j/reporting/schema/core-0.2.0.xsd");
+		schemas.put(Namespace.REPORTING_GIT_0_2_0, "/org/opentest4j/reporting/schema/git-0.2.0.xsd");
+		schemas.put(Namespace.REPORTING_JAVA_0_2_0, "/org/opentest4j/reporting/schema/java-0.2.0.xsd");
+		SCHEMAS = unmodifiableMap(schemas);
+	}
+
+	/**
+	 * {@return the schema location for the given built-in namespace}
+	 *
+	 * @param namespace the namespace to get the schema location for
+	 */
+	public static Optional<URL> getSchemaLocation(Namespace namespace) {
+		return Optional.ofNullable(SCHEMAS.get(namespace)) //
+				.map(Schemas.class::getResource);
+	}
+
+	private Schemas() {
+	}
+}

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidator.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/validator/DefaultValidator.java
@@ -18,6 +18,7 @@ package org.opentest4j.reporting.tooling.core.validator;
 
 import org.apiguardian.api.API;
 import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.schema.Schemas;
 import org.w3c.dom.ls.LSInput;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.ErrorHandler;
@@ -34,12 +35,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
@@ -55,17 +57,6 @@ import static org.opentest4j.reporting.tooling.core.validator.Severity.WARNING;
  */
 @API(status = EXPERIMENTAL, since = "0.1.0")
 public class DefaultValidator implements Validator {
-
-	private static final Map<Namespace, String> SCHEMAS = Map.of( //
-		Namespace.REPORTING_EVENTS_0_1_0, "/org/opentest4j/reporting/schema/events-0.1.0.xsd", //
-		Namespace.REPORTING_HIERARCHY_0_1_0, "/org/opentest4j/reporting/schema/hierarchy-0.1.0.xsd", //
-		Namespace.REPORTING_CORE_0_1_0, "/org/opentest4j/reporting/schema/core-0.1.0.xsd", //
-		Namespace.REPORTING_JAVA_0_1_0, "/org/opentest4j/reporting/schema/java-0.1.0.xsd", //
-		Namespace.REPORTING_EVENTS_0_2_0, "/org/opentest4j/reporting/schema/events-0.2.0.xsd", //
-		Namespace.REPORTING_HIERARCHY_0_2_0, "/org/opentest4j/reporting/schema/hierarchy-0.2.0.xsd", //
-		Namespace.REPORTING_CORE_0_2_0, "/org/opentest4j/reporting/schema/core-0.2.0.xsd", //
-		Namespace.REPORTING_GIT_0_2_0, "/org/opentest4j/reporting/schema/git-0.2.0.xsd", //
-		Namespace.REPORTING_JAVA_0_2_0, "/org/opentest4j/reporting/schema/java-0.2.0.xsd");
 
 	private final SchemaFactory schemaFactory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
 	private final CatalogResolver catalogResolver;
@@ -107,14 +98,15 @@ public class DefaultValidator implements Validator {
 		return (type, namespaceURI, publicId, systemId, baseURI) -> {
 			if (namespaceURI != null) {
 				var namespace = Namespace.of(namespaceURI);
-				if (SCHEMAS.containsKey(namespace)) {
+				var schemaLocation = Schemas.getSchemaLocation(namespace);
+				if (schemaLocation.isPresent()) {
 					LSInputImpl input = new LSInputImpl();
 					input.setPublicId(publicId);
-					var schema = SCHEMAS.get(namespace);
-					input.setSystemId(requireNonNull(Namespace.class.getResource(schema)).toExternalForm());
+					var url = schemaLocation.get();
+					input.setSystemId(url.toExternalForm());
 					input.setBaseURI(baseURI);
 					@SuppressWarnings("resource")
-					var stream = Namespace.class.getResourceAsStream(schema);
+					var stream = openStream(url);
 					input.setCharacterStream(new InputStreamReader(requireNonNull(stream)));
 					return input;
 				}
@@ -124,6 +116,15 @@ public class DefaultValidator implements Validator {
 			}
 			return null;
 		};
+	}
+
+	private static InputStream openStream(URL url) {
+		try {
+			return url.openStream();
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to read resource from " + url, e);
+		}
 	}
 
 	static class LSInputImpl implements LSInput {

--- a/tooling-core/src/module/java/org.opentest4j.reporting.tooling.core/module-info.java
+++ b/tooling-core/src/module/java/org.opentest4j.reporting.tooling.core/module-info.java
@@ -38,4 +38,6 @@ module org.opentest4j.reporting.tooling.core {
             org.opentest4j.reporting.tooling.core.htmlreport.CoreContributor,
             org.opentest4j.reporting.tooling.core.htmlreport.GitContributor,
             org.opentest4j.reporting.tooling.core.htmlreport.JavaContributor;
+
+    opens org.opentest4j.reporting.tooling.core.htmlreport to com.google.gson;
 }


### PR DESCRIPTION
* Avoid having to specify `--add-opens` for gson, picocli, and schema validation
* Avoid having to specify main class

Fixes #381.
