### PR TITLE
Add FreeBSD to CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,3 +47,35 @@ jobs:
     - name: Archive Open Test Reports
       uses: ./.github/actions/archive-reports
       if: ${{ always() }}
+
+  FreeBSD:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 1
+    - name: Run tests in FreeBSD VM
+      uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1.4.6
+      with:
+        release: "15.0"
+        arch: x86_64
+        sync: rsync
+        copyback: true
+        usesh: true
+        prepare: |
+          pkg install -y bash curl git openjdk17 openjdk25 node24 npm-node24
+          mount -t procfs proc /proc
+        run: |
+          pwd
+          freebsd-version
+          ./gradlew \
+          -Porg.gradle.java.installations.auto-download=false \
+          -Porg.gradle.java.installations.paths=/usr/local/openjdk17,/usr/local/openjdk25 \
+          -PopenTestReporting.nodeDownload=false \
+          --refresh-dependencies \
+          javaToolchains \
+          build
+    - name: Archive Open Test Reports
+      uses: ./.github/actions/archive-reports
+      if: ${{ always() }}

--- a/tooling-core/build.gradle.kts
+++ b/tooling-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 val htmlReportTemplate = configurations.dependencyScope("htmlReportTemplate")
 val sampleXmlReport = configurations.dependencyScope("sampleXmlReport")
+val isFreeBSD = System.getProperty("os.name").contains("FreeBSD", ignoreCase = true)
 
 dependencies {
     api(projects.schema)
@@ -43,7 +44,7 @@ tasks.test {
     jvmArgumentProviders.add(CommandLineArgumentProvider {
         listOf("-DsampleXmlReport=${sampleXmlReportFiles.get().singleFile.absolutePath}")
     })
-    if (System.getenv("CI") != null) {
+    if (System.getenv("CI") != null && !isFreeBSD) {
         doFirst(playwrightInstallationAction)
     }
 }

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterBrowserTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/htmlreport/DefaultHtmlReportWriterBrowserTests.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -45,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @UsePlaywright(DefaultHtmlReportWriterBrowserTests.CustomOptions.class)
 @ExtendWith({ PlaywrightTracePublisher.class, PlaywrightVideoPublisher.class })
+@DisabledOnOs(value = OS.FREEBSD, disabledReason = "Playwright does not support FreeBSD - https://github.com/microsoft/playwright/issues/20330")
 class DefaultHtmlReportWriterBrowserTests {
 
 	@TempDir


### PR DESCRIPTION
Attempt at adding FreeBSD to CI, and disabling the tests that depend on Playright on FreeBSD.
See https://github.com/ota4j-team/open-test-reporting/issues/1056