### PR TITLE
Add execution time in test tree sidebar

### DIFF
--- a/html-report/src/components/details/DurationLabel.vue
+++ b/html-report/src/components/details/DurationLabel.vue
@@ -3,7 +3,7 @@ import { computed } from "vue";
 import { Timer } from "@lucide/vue";
 import { defaultIconProps } from "../common/icon.ts";
 
-const props = defineProps<{ millis: number }>();
+const props = defineProps<{ millis: number; compact?: boolean }>();
 const parts = computed(() => {
   const result = Object.fromEntries(
     Object.entries({
@@ -22,10 +22,17 @@ const parts = computed(() => {
 
 <template>
   <div
-    class="inline-flex mb-2 border-2 rounded-full px-2 py-1 border-neutral-400 bg-neutral-300 dark:bg-neutral-500"
+    :class="
+      compact
+        ? 'inline-flex'
+        : 'inline-flex mb-2 border-2 rounded-full px-2 py-1 border-neutral-400 bg-neutral-300 dark:bg-neutral-500'
+    "
   >
-    <Timer v-bind="defaultIconProps" class="self-center" />
-    <span class="ml-1 text-sm font-bold self-center">
+    <Timer v-if="!compact" v-bind="defaultIconProps" class="self-center" />
+    <span
+      class="whitespace-nowrap self-center"
+      :class="compact ? 'text-xs font-thin' : 'ml-1 text-sm font-bold'"
+    >
       <span
         v-for="(value, label, index) in parts"
         :key="label"

--- a/html-report/src/components/sidebar/TreeNode.vue
+++ b/html-report/src/components/sidebar/TreeNode.vue
@@ -6,6 +6,7 @@ import TestExecution from "../common/TestExecution.ts";
 import Selection from "../common/Selection.ts";
 import { defaultIconProps } from "../common/icon.ts";
 import { treeStateKey } from "./TreeState.ts";
+import DurationLabel from "../details/DurationLabel.vue";
 /* global TestNodeData */
 
 const treeState = inject(treeStateKey)!;
@@ -39,7 +40,7 @@ if (defaultIconProps.size != 16) {
 <template>
   <div
     v-if="treeState.isVisible(execution.nodeStatuses(node as TestNodeData))"
-    class="inline-flex -mt-0.5"
+    class="inline-flex -mt-0.5 w-full"
   >
     <div
       v-if="children.length > 0"
@@ -53,7 +54,7 @@ if (defaultIconProps.size != 16) {
       <ChevronDown v-else v-bind="defaultIconProps" />
     </div>
     <div
-      class="cursor-pointer rounded-sm p-px px-1 inline-flex"
+      class="cursor-pointer rounded-sm p-px px-1 inline-flex w-full"
       :class="{
         'bg-neutral-300 dark:bg-neutral-600 font-bold': isSelected,
         'hover:bg-neutral-200 dark:hover:bg-neutral-700': !isSelected,
@@ -65,6 +66,9 @@ if (defaultIconProps.size != 16) {
     >
       <slot name="icon" v-bind="defaultIconProps" />
       <span class="ml-1 whitespace-nowrap">{{ node.name }}</span>
+      <div class="inline-flex w-full justify-end">
+        <DurationLabel :millis="node.durationMillis" :compact="true" />
+      </div>
     </div>
   </div>
   <TestNodeTree


### PR DESCRIPTION
Hi everyone,
this PR add the test execution time in the sidebar, as proposed in issue #711.

The implementation reuses the DurationLabel component, adding an alternative, compact visualization, used in the sidebar nodes, therefore it does not duplicate the duration formatting logic.