### PR TITLE
Fixes to allow conversion of variously ordered events

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ gson = { module = "com.google.code.gson:gson", version = "2.14.0" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
 immutables-valueAnnotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
+jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "6.1.2" }
 junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting", version = "6.1.2" }
 log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version = "2.26.1" }

--- a/tooling-core/build.gradle.kts
+++ b/tooling-core/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(projects.events)
     implementation(projects.toolingSpi)
     implementation(libs.gson)
+    compileOnly(libs.jspecify)
     compileOnlyApi(libs.apiguardian)
 
     testImplementation(libs.assertj.core)

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
@@ -17,6 +17,7 @@
 package org.opentest4j.reporting.tooling.core.converter;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.opentest4j.reporting.events.core.Infrastructure;
 import org.opentest4j.reporting.events.root.Event;
 import org.opentest4j.reporting.events.root.Finished;
@@ -38,7 +39,9 @@ import javax.xml.transform.stream.StreamResult;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -115,12 +118,15 @@ public class DefaultConverter implements Converter {
 		var targetNamespace = determineTargetNamespace(sourceRoot);
 		createRootElement(sourceRoot, targetDocument, targetNamespace);
 
+		// Map of @id -> Element
 		Map<String, Element> nodeById = new HashMap<>();
+		// Map of @parentId -> Child Elements, holds children whose parent has not yet been encountered
+		Map<String, List<ElementWithId>> pendingParentNode = new HashMap<>();
 
 		for (Node child = sourceRoot.getFirstChild(); child != null; child = child.getNextSibling()) {
 			if (child instanceof Element element) {
 				if (matches(Started.ELEMENT, element)) {
-					started(targetDocument, nodeById, element, targetNamespace);
+					started(targetDocument, pendingParentNode, nodeById, element, targetNamespace);
 				}
 				else if (matches(Reported.ELEMENT, element)) {
 					reported(nodeById, element);
@@ -157,31 +163,73 @@ public class DefaultConverter implements Converter {
 		targetDocument.getDocumentElement().appendChild(targetElement);
 	}
 
-	private void started(Document targetDocument, Map<String, Element> nodeById, Element sourceElement,
-			Namespace targetNamespace) {
-		Element parentElement;
+	private void started(Document targetDocument, Map<String, List<ElementWithId>> pendingParentNode,
+			Map<String, Element> nodeById, Element sourceElement, Namespace targetNamespace) {
+		@Nullable
+		String parentId = null;
+		@Nullable
+		Element parentElement = null;
 		Element targetElement;
 		if (sourceElement.hasAttribute(Started.PARENT_ID.getSimpleName())) {
 			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), CHILD_NODE_NAME);
-			parentElement = nodeById.get(sourceElement.getAttribute(Started.PARENT_ID.getSimpleName()));
-			if (parentElement == null) {
-				throw new IllegalStateException("Child has arrived before Parent");
-			}
+			parentId = sourceElement.getAttribute(Started.PARENT_ID.getSimpleName());
+			parentElement = nodeById.get(parentId);
 		}
 		else {
 			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), ROOT_NODE_NAME);
 			parentElement = targetDocument.getDocumentElement();
 		}
-		parentElement.appendChild(targetElement);
-
-		String id = sourceElement.getAttribute(Event.ID.getSimpleName());
-		nodeById.put(id, targetElement);
 
 		copyAttributes(sourceElement, targetElement, (name, __) -> !EVENT_ONLY_ATTRIBUTES.contains(name));
 		copyChildren(sourceElement, targetElement);
 
 		if (sourceElement.hasAttribute(Event.TIME.getSimpleName())) {
 			targetElement.setAttribute(START_ATTRIBUTE_NAME, sourceElement.getAttribute(Event.TIME.getSimpleName()));
+		}
+
+		String id = sourceElement.getAttribute(Event.ID.getSimpleName());
+		if (parentElement == null) {
+			// if we have not yet encountered the parent element, then store the child element in the pending list
+			List<ElementWithId> childElementsPendingParent = pendingParentNode.computeIfAbsent(parentId,
+				key -> new ArrayList<>());
+			childElementsPendingParent.add(new ElementWithId(id, targetElement));
+		}
+		else {
+			// resolve any pending child elements that have been waiting for their parent element
+			resolvePendingChildElements(id, targetElement, pendingParentNode, nodeById);
+
+			// attach child to parent
+			nodeById.put(id, targetElement);
+			parentElement.appendChild(targetElement);
+		}
+	}
+
+	/**
+	 * Finds any pending children (and descendents) for a parent element, and attaches them to the parent element.
+	 *
+	 * @param parentId the id of the parent element
+	 * @param parentElement the parent element itself
+	 * @param pendingParentNode map of children that are awaiting their parent node; Map key is parentId. Map may be modified by this function.
+	 * @param nodeById a map of nodes that have been processed; Map key is the element id. Map may be modified by this function.
+	 */
+	private void resolvePendingChildElements(String parentId, Element parentElement,
+			Map<String, List<ElementWithId>> pendingParentNode, Map<String, Element> nodeById) {
+		if (pendingParentNode.isEmpty()) {
+			return;
+		}
+
+		@Nullable
+		List<ElementWithId> childElementsPendingParent = pendingParentNode.remove(parentId);
+		if (childElementsPendingParent != null) {
+			for (ElementWithId child : childElementsPendingParent) {
+
+				// resolve descendents
+				resolvePendingChildElements(child.id, child.element, pendingParentNode, nodeById);
+
+				// attach child to parent
+				nodeById.put(child.id, child.element);
+				parentElement.appendChild(child.element);
+			}
 		}
 	}
 
@@ -254,4 +302,15 @@ public class DefaultConverter implements Converter {
 					targetElement.appendChild(targetChild);
 				});
 	}
+
+	private static class ElementWithId {
+		final String id;
+		final Element element;
+
+		ElementWithId(final String id, final Element element) {
+			this.id = id;
+			this.element = element;
+		}
+	}
+
 }

--- a/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
+++ b/tooling-core/src/main/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverter.java
@@ -159,15 +159,20 @@ public class DefaultConverter implements Converter {
 
 	private void started(Document targetDocument, Map<String, Element> nodeById, Element sourceElement,
 			Namespace targetNamespace) {
+		Element parentElement;
 		Element targetElement;
 		if (sourceElement.hasAttribute(Started.PARENT_ID.getSimpleName())) {
 			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), CHILD_NODE_NAME);
-			nodeById.get(sourceElement.getAttribute(Started.PARENT_ID.getSimpleName())).appendChild(targetElement);
+			parentElement = nodeById.get(sourceElement.getAttribute(Started.PARENT_ID.getSimpleName()));
+			if (parentElement == null) {
+				throw new IllegalStateException("Child has arrived before Parent");
+			}
 		}
 		else {
 			targetElement = targetDocument.createElementNS(targetNamespace.getUri(), ROOT_NODE_NAME);
-			targetDocument.getDocumentElement().appendChild(targetElement);
+			parentElement = targetDocument.getDocumentElement();
 		}
+		parentElement.appendChild(targetElement);
 
 		String id = sourceElement.getAttribute(Event.ID.getSimpleName());
 		nodeById.put(id, targetElement);

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
@@ -172,7 +172,7 @@ class DefaultConverterTests {
 	@ParameterizedTest
 	@ValueSource(strings = { "events-ordered-1.xml", "events-ordered-2.xml", "events-unordered-1.xml",
 			"events-unordered-2.xml" })
-	void covertEventOrders(final String eventXmlFilename) throws Exception {
+	void convertsRegardlessOfEventOrder(final String eventXmlFilename) throws Exception {
 		final URL url = getClass().getResource(eventXmlFilename);
 		final Path eventXml = Paths.get(url.toURI());
 		new DefaultConverter().convert(eventXml, targetFile);

--- a/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
+++ b/tooling-core/src/test/java/org/opentest4j/reporting/tooling/core/converter/DefaultConverterTests.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentest4j.reporting.events.api.DocumentWriter;
 import org.opentest4j.reporting.events.api.NamespaceRegistry;
 import org.opentest4j.reporting.events.root.Events;
@@ -30,8 +32,10 @@ import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -157,6 +161,21 @@ class DefaultConverterTests {
 		assertAll(targetFile, NamespaceVersion.parse("0.1.0"), //
 			it -> it.nodesByXPath("//h:execution").hasSize(1), //
 			it -> it.valueByXPath("//*/c:infrastructure/c:cpuCores").isEqualTo(42));
+	}
+
+	/**
+	 * Tests the conversion of Events XML files
+	 * with various orders of the start/finished events
+	 * including children arriving before parents.
+	 * @see <a href="https://github.com/ota4j-team/open-test-reporting/issues/1054">HtmlReportWriter expects Events XML files to have a particular (undocumented) order</a>
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "events-ordered-1.xml", "events-ordered-2.xml", "events-unordered-1.xml",
+			"events-unordered-2.xml" })
+	void covertEventOrders(final String eventXmlFilename) throws Exception {
+		final URL url = getClass().getResource(eventXmlFilename);
+		final Path eventXml = Paths.get(url.toURI());
+		new DefaultConverter().convert(eventXml, targetFile);
 	}
 
 	private void writeXml(Path eventsXmlFile, Consumer<DocumentWriter<Events>> action) throws Exception {

--- a/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-ordered-1.xml
+++ b/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-ordered-1.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0">
+    <infrastructure>
+        <hostName>formaggio</hostName>
+        <operatingSystem>FreeBSD</operatingSystem>
+        <cpuCores>16</cpuCores>
+    </infrastructure>
+    <e:started id="fots" name="FOTS 3.1" time="2026-07-07T12:10:05.290301653Z"/>
+    <e:started id="fots-fn-analyze-string" name="fn-analyze-string" parentId="fots" time="2026-07-07T12:10:05.415589001Z"/>
+    <e:started id="fots-fn-analyze-string-001" name="analyzeString-001" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418354409Z"/>
+    <e:started id="fots-fn-analyze-string-002" name="analyzeString-002" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418454962Z"/>
+    <e:started id="fots-fn-analyze-string-003" name="analyzeString-003" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418653132Z"/>
+    <e:started id="fots-fn-analyze-string-004" name="analyzeString-004" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418707782Z"/>
+    <e:started id="fots-fn-analyze-string-005" name="analyzeString-005" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418764521Z"/>
+    <e:finished id="fots-fn-analyze-string-001" time="2026-07-07T12:10:05.500486744Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-002" time="2026-07-07T12:10:05.501074313Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-003" time="2026-07-07T12:10:05.500405585Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-004" time="2026-07-07T12:10:05.500482390Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-005" time="2026-07-07T12:10:05.500953471Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string" time="2026-07-07T12:10:05.424252577Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots" time="2026-07-07T12:10:05.438107769Z"><result status="SUCCESSFUL"/></e:finished>
+</e:events>

--- a/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-ordered-2.xml
+++ b/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-ordered-2.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0">
+    <infrastructure>
+        <hostName>formaggio</hostName>
+        <operatingSystem>FreeBSD</operatingSystem>
+        <cpuCores>16</cpuCores>
+    </infrastructure>
+    <e:started id="fots" name="FOTS 3.1" time="2026-07-07T12:10:05.290301653Z"/>
+    <e:started id="fots-fn-analyze-string" name="fn-analyze-string" parentId="fots" time="2026-07-07T12:10:05.415589001Z"/>
+    <e:started id="fots-fn-analyze-string-001" name="analyzeString-001" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418354409Z"/>
+    <e:finished id="fots-fn-analyze-string-001" time="2026-07-07T12:10:05.500486744Z"><result status="ERRORED"/></e:finished>
+    <e:started id="fots-fn-analyze-string-002" name="analyzeString-002" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418454962Z"/>
+    <e:finished id="fots-fn-analyze-string-002" time="2026-07-07T12:10:05.501074313Z"><result status="ERRORED"/></e:finished>
+    <e:started id="fots-fn-analyze-string-003" name="analyzeString-003" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418653132Z"/>
+    <e:finished id="fots-fn-analyze-string-003" time="2026-07-07T12:10:05.500405585Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:started id="fots-fn-analyze-string-004" name="analyzeString-004" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418707782Z"/>
+    <e:finished id="fots-fn-analyze-string-004" time="2026-07-07T12:10:05.500482390Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:started id="fots-fn-analyze-string-005" name="analyzeString-005" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418764521Z"/>
+    <e:finished id="fots-fn-analyze-string-005" time="2026-07-07T12:10:05.500953471Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string" time="2026-07-07T12:10:05.424252577Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots" time="2026-07-07T12:10:05.438107769Z"><result status="SUCCESSFUL"/></e:finished>
+</e:events>

--- a/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-unordered-1.xml
+++ b/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-unordered-1.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0">
+    <infrastructure>
+        <hostName>formaggio</hostName>
+        <operatingSystem>FreeBSD</operatingSystem>
+        <cpuCores>16</cpuCores>
+    </infrastructure>
+    <e:started id="fots" name="FOTS 3.1" time="2026-07-07T12:10:05.290301653Z"/>
+    <e:started id="fots-fn-analyze-string-001" name="analyzeString-001" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418354409Z"/>
+    <e:started id="fots-fn-analyze-string-002" name="analyzeString-002" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418454962Z"/>
+    <e:started id="fots-fn-analyze-string-003" name="analyzeString-003" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418653132Z"/>
+    <e:started id="fots-fn-analyze-string" name="fn-analyze-string" parentId="fots" time="2026-07-07T12:10:05.415589001Z"/>
+    <e:started id="fots-fn-analyze-string-004" name="analyzeString-004" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418707782Z"/>
+    <e:started id="fots-fn-analyze-string-005" name="analyzeString-005" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418764521Z"/>
+    <e:finished id="fots-fn-analyze-string-002" time="2026-07-07T12:10:05.501074313Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-004" time="2026-07-07T12:10:05.500482390Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string" time="2026-07-07T12:10:05.424252577Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots" time="2026-07-07T12:10:05.438107769Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-001" time="2026-07-07T12:10:05.500486744Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-003" time="2026-07-07T12:10:05.500405585Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-005" time="2026-07-07T12:10:05.500953471Z"><result status="ERRORED"/></e:finished>
+</e:events>

--- a/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-unordered-2.xml
+++ b/tooling-core/src/test/resources/org/opentest4j/reporting/tooling/core/converter/events-unordered-2.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0">
+    <infrastructure>
+        <hostName>formaggio</hostName>
+        <operatingSystem>FreeBSD</operatingSystem>
+        <cpuCores>16</cpuCores>
+    </infrastructure>
+    <e:started id="fots" name="FOTS 3.1" time="2026-07-07T12:10:05.290301653Z"/>
+    <e:started id="fots-fn-analyze-string" name="fn-analyze-string" parentId="fots" time="2026-07-07T12:10:05.415589001Z"/>
+    <e:started id="fots-fn-analyze-string-001" name="analyzeString-001" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418354409Z"/>
+    <e:started id="fots-fn-analyze-string-002" name="analyzeString-002" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418454962Z"/>
+    <e:finished id="fots-fn-analyze-string-002" time="2026-07-07T12:10:05.501074313Z"><result status="ERRORED"/></e:finished>
+    <e:started id="fots-fn-analyze-string-003" name="analyzeString-003" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418653132Z"/>
+    <e:started id="fots-fn-analyze-string-004" name="analyzeString-004" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418707782Z"/>
+    <e:finished id="fots-fn-analyze-string-003" time="2026-07-07T12:10:05.500405585Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:started id="fots-fn-analyze-string-005" name="analyzeString-005" parentId="fots-fn-analyze-string" time="2026-07-07T12:10:05.418764521Z"/>
+    <e:finished id="fots" time="2026-07-07T12:10:05.438107769Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string" time="2026-07-07T12:10:05.424252577Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-004" time="2026-07-07T12:10:05.500482390Z"><result status="SUCCESSFUL"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-001" time="2026-07-07T12:10:05.500486744Z"><result status="ERRORED"/></e:finished>
+    <e:finished id="fots-fn-analyze-string-005" time="2026-07-07T12:10:05.500953471Z"><result status="ERRORED"/></e:finished>
+</e:events>


### PR DESCRIPTION
When processing Events XML we now buffer child elements whose parents we have not yet encountered.

Closes https://github.com/ota4j-team/open-test-reporting/issues/1054