### PR TITLE
Install Playwright browsers (and deps) from build to fix caching

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -36,9 +36,7 @@ runs:
       id: playwright-cache
       with:
         path: ${{ github.workspace }}/.gradle/playwright
-        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.value }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
+        key: ${{ runner.os }}-playwright-v2-${{ steps.playwright-version.outputs.value }}
     - shell: bash
       env:
         JAVA_HOME: ${{ steps.setup-gradle-jdk.outputs.path }}

--- a/tooling-core/build.gradle.kts
+++ b/tooling-core/build.gradle.kts
@@ -28,11 +28,11 @@ tasks.compileJava {
     options.release = 17
 }
 
-val playwrightInstallationAction = objects.newInstance(InstallPlaywrightDeps::class).apply {
+val playwrightInstallationAction = objects.newInstance(InstallPlaywright::class).apply {
     classpath.from(configurations.testRuntimeClasspath)
 }
 
-val installPlaywrightDeps = tasks.register("installPlaywrightDeps") {
+val installPlaywright = tasks.register("installPlaywright") {
     doFirst(playwrightInstallationAction)
 }
 
@@ -47,17 +47,17 @@ tasks.test {
         listOf("-DsampleXmlReport=${sampleXmlReportFiles.singleFile.absolutePath}")
     })
     if (System.getenv("CI") != null && !isFreeBSD) {
-        doFirst(playwrightInstallationAction)
+        dependsOn(installPlaywright)
     }
 }
 
-abstract class InstallPlaywrightDeps @Inject constructor (private val execOperations: ExecOperations) : Action<Task> {
+abstract class InstallPlaywright @Inject constructor (private val execOperations: ExecOperations) : Action<Task> {
     abstract val classpath: ConfigurableFileCollection
     override fun execute(t: Task) {
         execOperations.javaexec {
-            classpath(this@InstallPlaywrightDeps.classpath)
+            classpath(this@InstallPlaywright.classpath)
             mainClass = "com.microsoft.playwright.CLI"
-            args("install-deps")
+            args("install", "--with-deps")
         }
     }
 }


### PR DESCRIPTION
Since the GH Actions cache only gets written on pushed to `main`, the
cache entry was incomplete in case the `:tooling-core:test` task was
loaded from the build cache. Prior to this commit, only dependencies
were installed by the build, but the browsers were downloaded by the
JUnit Jupiter extension.
